### PR TITLE
Incorporate `device`/strides/offsets into indexing pipeline

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -4,7 +4,7 @@ using Requires
 using LinearAlgebra
 using SparseArrays
 
-using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice
+using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, front
 
 Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))
@@ -51,7 +51,6 @@ end
 end
 _known_length(x::Tuple{Vararg{<:Union{Int,Nothing}}}) = nothing
 _known_length(x::Tuple{Vararg{Int}}) = prod(x)
-
 
 """
     can_change_size(::Type{T}) -> Bool
@@ -580,6 +579,15 @@ function device(::Type{T}) where {T <: AbstractArray}
     T === P ? CPUIndex() : device(P)
 end
 
+"""
+    memory_offset(x) -> Integer
+
+Returns the offset from zero of the first element of `x` given it's pointer.
+(e.i., `unsafe_load(pointer(x) + memory_offset(x))` should return the value of `x`).
+"""
+@inline memory_offset(x) = memory_offset(device(x), x)
+@inline memory_offset(::CPUPointer, x) = pointer(x)
+memory_offset(::Any, x) = throw("Memory access for $(typeof(x)) not implemented yet.")
 
 """
 defines_strides(::Type{T}) -> Bool
@@ -900,7 +908,8 @@ end
 include("static.jl")
 include("ranges.jl")
 include("dimensions.jl")
-include("indexing.jl")
 include("stridelayout.jl")
+include("indexing.jl")
+include("parsing.jl")
 
 end

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -563,7 +563,13 @@ For other `AbstractArray`s and `Tuple`s, returns `ArrayInterface.CPUIndex()`.
 Otherwise, returns `nothing`.
 """
 device(A) = device(typeof(A))
-device(::Type) = nothing
+function device(::Type{T}) where {T}
+    if parent_type(T) <: T
+        return nothing
+    else
+        return CheckParent()
+    end
+end
 device(::Type{<:Tuple}) = CPUIndex()
 # Relies on overloading for GPUArrays that have subtyped `StridedArray`.
 device(::Type{<:StridedArray}) = CPUPointer()

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,0 +1,386 @@
+
+rangeexpr(start, st, stop) = Expr(:call, :(:), start, st, stop)
+function rangeexpr(start, st::Integer, stop)
+    if st === 1
+        return :($start:$stop)
+        return Expr(:call, :(:), start, stop)
+    else
+        return Expr(:call, :(:), start, st, stop)
+    end
+end
+function rangeexpr(start::Integer, st::Integer, stop::Integer)
+    if st === 1
+        return Int(start):Int(stop)
+    else
+        return Int(start):Int(st):Int(stop)
+    end
+end
+
+###
+### addition
+###
+_addexpr(x::Symbol, y::Int) = :($x + $y)
+function _addexpr(x::Expr, y::Int)
+    if y === 0
+        return x
+    elseif x.head === :call && x.args[2] === :+
+        if x.arg[2] isa Integer
+            x.argp[2] += y
+            return x, 0
+        elseif x.arg[3] isa Integer
+            x.argp[3] += y
+            return x, 0
+        else
+            _, newy = _addexpr(x.args[2], y)
+            if newy === 0
+                return x, newy
+            else
+                _, newy = _addexpr(x.args[3], y)
+                return x, newy
+            end
+        end
+    else
+        return x, y
+    end
+end
+addexpr(x::Integer, y::Integer) = Int(x) + Int(y)
+addexpr(x::Union{Symbol,Expr}, y::Union{Symbol,Expr}) = :($x + $y)
+addexpr(x::Integer, y::Union{Expr,Symbol}) = addexpr(y, Int(x))
+function addexpr(x::Union{Symbol,Expr}, y::Integer)
+    if Int(y) === 0
+        return x
+    else
+        newx, newy = _addexpr(x, Int(y))
+        if newy === 0
+            return newx
+        else
+            return :($x + $y)
+        end
+    end
+end
+
+lengthexpr(x) = length(x)
+lengthexpr(x::Expr) = :(length($x))
+
+###
+### subtraction
+###
+subexpr(x::Integer, y::Integer) = addexpr(x, -y)
+subexpr(x::Union{Symbol,Expr}, y::Union{Symbol,Expr}) = :($x - $y)
+function subexpr(x::Union{Symbol,Expr}, y::Integer)
+    if Int(y) === 0
+        return x
+    else
+        return :($x - $y)
+    end
+end
+function subexpr(x::Integer, y::Union{Symbol,Expr})
+    if Int(x) === 0
+        return y
+    else
+        return :($x - $y)
+    end
+end
+
+###
+### multiplication
+###
+mulexpr(x::Union{Symbol,Expr}, y::Union{Symbol,Expr}) = :($x * $y)
+mulexpr(x::Integer, y::Integer) = Int(x) * Int(y)
+mulexpr(x::Integer, y::Union{Symbol,Expr}) = mulexpr(y, x)
+function mulexpr(x::Union{Symbol,Expr}, y::Integer)
+    newy = Int(y)
+    if Int(y) === 0
+        return 0
+    elseif Int(y) === 1
+        return x
+    else
+        newx, newy = _mulexpr(x, Int(y))
+        if newy === 1
+            return newx
+        else
+            return :($x * $y)
+        end
+    end
+end
+
+_mulexpr(x::Symbol, y::Int) = :($x * $y), 1
+function _mulexpr(x::Expr, y::Int)
+    if y === 0
+        return 0
+    elseif y === 1
+        return x
+    elseif x.head === :call && x.args[2] === :*
+        if x.arg[2] isa Integer
+            x.argp[2] *= y
+            return x, 1
+        elseif x.arg[3] isa Integer
+            x.argp[3] *= y
+            return x, 1
+        else
+            _, newy = _addexpr(x.args[2], y)
+            if newy === 1
+                return x, newy
+            else
+                _, newy = _addexpr(x.args[3], y)
+                return x, newy
+            end
+        end
+    else
+        return x, y
+    end
+end
+
+
+known_struct(::Type{T}) where {T} = nothing
+known_struct(::Type{T}) where {N,T<:StaticInt{N}} = StaticInt{N}()
+function known_struct(::Type{T}) where {T<:OptionallyStaticRange}
+    if known_first(T) === nothing
+        return nothing
+    else
+        if known_step(T) === nothing
+            return nothing
+        else
+            if known_last(T) === nothing
+                return nothing
+            else
+                if known_step(T) === 1
+                    return known_first(T):known_last(T)
+                else
+                    return known_first(T):known_step(T):known_last(T)
+                end
+            end
+        end
+    end
+end
+
+#=
+const ElementMap = IndexMap{Int,Int,Nothing}
+const CollectionMap = IndexMap{Int,Int,Int}
+const CartesianCollectionMap{N} = IndexMap{NTuple{N,Int},Int,Int}
+const CartesianElementMap{N} = IndexMap{NTuple{N,Int},Int,nothing}
+const SliceMap{N} = IndexMap{NTuple{N,Int},NTuple{N,Int},NTuple{N,Int}}
+=#
+
+struct IndexExpr
+    assignment::Vector{Expr}
+    iterator::Expr
+    strided::Union{Symbol,Expr}
+end
+
+###
+### index across contiguously sliced strides
+###
+function index_expr(
+    m::IndexMap{NTuple{N,Int},NTuple{N,Int},NTuple{N,Int}},
+    isym::Symbol, ::Type{I},
+    ssym::Symbol, ::Type{S},
+    fsym::Symbol, ::Type{F}
+) where {S,I,F,N}
+
+    idx_i = idx_map(m)
+    src_i = src_map(m)
+    index_i = gensym(Symbol(isym, :_, idx_i))
+    itrsym = gensym()
+    index = lengthexpr(_index_expr(I, isym, src_i[1]))
+    if N > 1
+        for i in 2:N
+            index = mulexpr(index, lengthexpr(_index_expr(I, isym, src_i[1])))
+        end
+    end
+    # TODO can we assume that offset of the memory is always 0
+    return IndexExpr(
+        [Expr(:(=), index_i, rangeexpr(0, 1, subexpr(index, 1)))],
+        :($itrsym = $index_i),
+        mulexpr(itrsym, _index_expr(S, ssym, src_i[1]))
+    )
+end
+
+###
+### index across linear collection
+###
+function index_expr(
+    m::IndexMap{Int,Int,Int},
+    isym::Symbol, ::Type{I},
+    ssym::Symbol, ::Type{S},
+    fsym::Symbol, ::Type{F}
+) where {S,I,F}
+
+    idx_i = idx_map(m)
+    src_i = src_map(m)
+    index_i = gensym(Symbol(isym, :_, idx_i))
+    itrsym = gensym(Symbol(:itr_, idx_i))
+    index = _index_expr(I, isym, idx_i)
+    offset = _index_expr(F, fsym, src_i)
+    if index isa Expr || offset isa Expr
+        index = :($index .- $offset)
+    else
+        index = index .- offset
+    end
+    return IndexExpr([Expr(:(=), index_i, index)], :($itrsym = $index_i), mulexpr(itrsym, _index_expr(S, ssym, src_i)))
+end
+
+###
+### index across multidimensional collection
+###
+function index_expr(
+    m::IndexMap{NTuple{N,Int},Int,Int},
+    isym::Symbol, ::Type{I},
+    ssym::Symbol, ::Type{S},
+    fsym::Symbol, ::Type{F}
+) where {I,S,F,N}
+
+    idx_i = idx_map(x)
+    src_i = src_map(x)
+    index_i = gensym(Symbol(isym, :_, idx_i))
+    itrsym = gensym(Symbol(:itr_, idx_i))
+    str = mulexpr(subexpr(:($itrsym[1]), _index_expr(F, fsym, src_i[1])), _index_expr(S, ssym, src_i[1]))
+    if N > 1
+        for i in 2:N
+            str = addexpr(str, mulexpr(subexpr(:($itrsym[$i]), _index_expr(F, fsym, src_i[i])), _index_expr(S, ssym, src_i[i])))
+        end
+    end
+    return IndexExpr([Expr(:(=), index_i, :($isym[$idx_i]))], :($itrsym = $index_i), str)
+end
+
+###
+### combine indices that are dropped
+### 
+struct DroppedExpr
+    sym::Symbol
+    assignment::Expr
+end
+
+function index_expr(
+    maps::DroppedIndexMaps,
+    isym::Symbol, ::Type{I},
+    ssym::Symbol, ::Type{S},
+    fsym::Symbol, ::Type{F}
+) where {S,I,F}
+
+    index_i = gensym(Symbol(isym))
+    return DroppedExpr(
+        index_i,
+        _index_expr_dropped_indices(maps.maps, isym, I, ssym, S, fsym, F))
+end
+function _index_expr_dropped_indices(
+    maps::Tuple{Any},
+    indices_sym::Symbol, ::Type{I},
+    strides_sym::Symbol, ::Type{S},
+    offsets_sym::Symbol, ::Type{F}
+) where {S,I,F}
+    x = first(maps)
+    index = _index_expr(I, indices_sym, idx_map(x))
+    stride = _index_expr(S, strides_sym, src_map(x))
+    offset = _index_expr(F, offsets_sym, src_map(x))
+    return mulexpr(subexpr(index, offset), stride)
+end
+
+function _index_expr_dropped_indices(
+    maps::Tuple{Any,Vararg},
+    indices_sym::Symbol, ::Type{I},
+    strides_sym::Symbol, ::Type{S},
+    offsets_sym::Symbol, ::Type{F}
+) where {S,I,F}
+
+    x = first(maps)
+    index = _index_expr(I, indices_sym, idx_map(x))
+    stride = _index_expr(S, strides_sym, src_map(x))
+    offset = _index_expr(F, offsets_sym, src_map(x))
+    return addexpr(
+        mulexpr(subexpr(index, offset), stride),
+        _index_expr_dropped_indices(tail(maps), indices_sym, I, strides_sym, S, offsets_sym, F)
+    )
+end
+
+function _index_expr(::Type{T}, sym::Symbol, i::Int) where {T}
+    _index_expr(known_struct(T.parameters[i]), sym, i)
+end
+_index_expr(::Nothing, sym::Symbol, i::Int) = :($sym[$i])
+_index_expr(x, sym::Symbol, i::Int) = x
+
+@inline function index_expr(
+    maps::Tuple{Any,Vararg},
+    isym::Symbol, ::Type{I},
+    ssym::Symbol, ::Type{S},
+    fsym::Symbol, ::Type{F}
+) where {S,I,F}
+
+    return (
+        index_expr(first(maps), isym, I, ssym, S, fsym, F),
+        index_expr(tail(maps), isym, I, ssym, S, fsym, F)...
+    )
+end
+
+function index_expr(
+    maps::Tuple{Any},
+    isym::Symbol, ::Type{I},
+    ssym::Symbol, ::Type{S},
+    fsym::Symbol, ::Type{F}
+) where {S,I,F}
+
+    return (index_expr(first(maps), isym, I, ssym, S, fsym, F),)
+end
+
+# dropped indices will still provide offset on the indexing within each body of higher
+# positioned iterating indices
+function combine_dropped_with_iterators(x::Tuple{DroppedExpr,Vararg})
+    dropped = first(x)
+    m = first(tail(x))
+    newexpr = IndexExpr([m.assignment..., Expr(:(=), dropped.sym, dropped.assignment)], m.iterator, addexpr(dropped.sym, m.strided))
+    return (newexpr, combine_dropped_with_iterators(tail(tail(x)))...)
+end
+
+combine_dropped_with_iterators(::Tuple{}) = ()
+function combine_dropped_with_iterators(x::Tuple{Any,Vararg})
+    return (first(x), combine_dropped_with_iterators(tail(x))...)
+end
+
+# last DroppedExpr goes at top of function body so we don't drop it
+combine_dropped_with_iterators(x::Tuple{DroppedExpr}) = x
+combine_dropped_with_iterators(x::Tuple{Any}) = x
+
+function generate_pointer_index(maps::Tuple{Vararg{Any,N}}, ::Type{T}) where {N,T}
+    blk = Expr(:block)
+    for m in maps
+        if !isa(m, DroppedExpr)
+            append!(blk.args, m.assignment)
+        end
+    end
+    bitsize = sizeof(T)
+
+    if N > 1
+        strided_assignments = [gensym(Symbol(:strided_, i)) for i in 1:(N + 1)]
+        m = maps[1]
+        out = Expr(:for, m.iterator,
+               Expr(:block, Expr(:(=), strided_assignments[1], addexpr(m.strided, strided_assignments[2])),
+                    :(dst_i === nothing && break),
+                    :(unsafe_copyto!(dst + (first(dst_i) * $bitsize), src + ($(strided_assignments[1]) * $bitsize), 1)),
+                    :(dst_i = iterate(dst_itr, last(dst_i)))))
+        for i in 2:N
+            m = maps[i]
+            if i === N
+                if isa(m, DroppedExpr)
+                    push!(blk.args, Expr(:(=), strided_assignments[i], m.assignment))
+                else
+                    out = Expr(:for, m.iterator, Expr(:block, Expr(:(=), strided_assignments[i], m.strided), out))
+                end
+            else
+                out = Expr(:for,
+                        m.iterator,
+                        Expr(:block, Expr(:(=), strided_assignments[i], addexpr(m.strided, strided_assignments[i+1])), out))
+            end
+        end
+    else
+        m = maps[1]
+        strided_1 = gensym(:strided_1)
+        out = Expr(:for, m.iterator, Expr(:block, :($strided_1 = $(m.strided)),
+                                          :(dst_i === nothing && break),
+                                          :(unsafe_copyto!(dst + (first(dst_i) * $bitsize), src + ($strided_1 * $bitsize), 1)),
+                                          :(dst_i = iterate(dst_itr, last(dst_i)))))
+    end
+    push!(blk.args, out)
+    return blk
+end
+
+

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -434,3 +434,12 @@ end
   return Base.Slice(OptionallyStaticUnitRange(fst, lst))
 end
 
+@inline function Base.iterate(r::OptionallyStaticRange, i::Integer)
+    if static_last(r) == i
+        return nothing
+    else
+        out = static_step(r) + i
+        return out, out
+    end
+end
+

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -105,11 +105,11 @@ contiguous_batch_size(::Type{<:Tuple}) = ContiguousBatch{0}()
 contiguous_batch_size(::Type{<:Union{Transpose{T,A},Adjoint{T,A}}}) where {T,A<:AbstractVecOrMat{T}} = contiguous_batch_size(A)
 contiguous_batch_size(::Type{<:PermutedDimsArray{T,N,I1,I2,A}}) where {T,N,I1,I2,A<:AbstractArray{T,N}} = contiguous_batch_size(A)
 function contiguous_batch_size(::Type{S}) where {N,NP,T,A<:AbstractArray{T,NP},I,S <: SubArray{T,N,A,I}}
-    _contiguous_batch_size(S, contiguous_batch_size(A), contiguous_axis(A))
+    _contiguous_batch_size(I, contiguous_batch_size(A), contiguous_axis(A))
 end
 _contiguous_batch_size(::Any, ::Any, ::Any) = nothing
-@generated function _contiguous_batch_size(::Type{S}, ::ContiguousBatch{B}, ::Contiguous{C}) where {B,C,N,NP,T,A<:AbstractArray{T,NP},I,S <: SubArray{T,N,A,I}}
-    if I.parameters[C] <: AbstractUnitRange
+@generated function _contiguous_batch_size(::Type{I}, ::ContiguousBatch{B}, ::Contiguous{C}) where {I,B,C}
+    if known_step(I.parameters[C]) === 1
         Expr(:call, Expr(:curly, :ContiguousBatch, B))
     else
         Expr(:call, Expr(:curly, :ContiguousBatch, -1))

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -294,7 +294,7 @@ end
     strd = stride(parent(x), One())
     (strd, strd)
 end
-                
+
 @generated function _strides(A::AbstractArray{T,N}, s::NTuple{N}, ::Contiguous{C}) where {T,N,C}
     if C ≤ 0 || C > N
         return Expr(:block, Expr(:meta,:inline), :s)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -154,3 +154,105 @@ end
         @test @inferred(ArrayInterface.getindex(LinearIndices(A),ArrayInterface.getindex(CartesianIndices(A),i))) == i
     end
 end
+
+@testset "IndexMap" begin
+    x = ones(Int, 4, 4,4,4);
+    inds = (Base.Slice(1:4),Base.Slice(1:4),1:4,Base.Slice(1:4))
+    ArrayInterface.index_by_pointer(ones(Int, 4, 4,4,4), (Base.Slice(1:4),Base.Slice(1:4),1:4,Base.Slice(1:4)))
+
+    loop = ArrayInterface.index_loops(x, inds)
+    index_expr(index_loops(x, inds), :inds, typeof(inds), :s, typeof(s), :f, typeof(f))
+
+    @test ArrayInterface.index_maps(x, inds) == (IndexMap((1,2),(1,2)),IndexMap(3,3),IndexMap(4,4))
+    inds = (Base.Slice(1:4),Base.Slice(1:4),1,Base.Slice(1:4))
+    @test ArrayInterface.index_maps(x, inds) == (IndexMap((1,2),(1,2)),IndexMap(3,nothing),IndexMap(4,3))
+    inds = (3:4, 3, 4,5)
+    @test ArrayInterface.index_maps(x, inds) == (IndexMap(1,1),IndexMap(2,nothing),IndexMap(3,nothing),IndexMap(4,nothing))
+
+    ArrayInterface.combine_index_maps(ArrayInterface.index_maps(x, inds))
+    ArrayInterface.index_loops(x, inds)
+end
+
+
+
+#=
+inds = (One():StaticInt(4), One():StaticInt(4), One():StaticInt(4))
+strs = (One(), StaticInt(4), StaticInt(16))
+itr = StridedIndexingIterator(inds, strs, One())
+[i for i in itr]
+
+=#
+
+A = zeros(Int, 3,4,5, 6);
+A[LinearIndices(A)] .= LinearIndices(A);
+Ap = PermutedDimsArray(A, (4,1,2, 3));
+Apv = @view(Ap[2,:,2:3])
+Apvadj = Apv'
+
+A = zeros(Int, 3,4,5);
+A[LinearIndices(A)] .= LinearIndices(A);
+Ap = PermutedDimsArray(A, (3,1,2));
+Apv = @view(Ap[2,:,2:3])
+Apvadj = Apv'
+
+collect(StridedIterator(A)) == [A...]
+collect(StridedIndexingIterator(Ap)) == [Ap...]
+collect(StridedIndexingIterator(Apv)) == [Apv...]
+collect(StridedIndexingIterator(Apvadj)) == [Apvadj...]
+
+function test_pointer_iterator(x)
+    src = pointer(x)
+    for (i, x_i) in zip(StridedIndexingIterator(A),x)
+        @test unsafe_load(src, i)
+    end
+end
+
+
+using ArrayInterface: IndexMap
+
+collect(StridedIterator((1:4, 2:4), (1, 1), (1, 4), 1))
+
+A = ones(Int, 4, 4);
+A[LinearIndices(A)] .= LinearIndices(A);
+Ap = PermutedDimsArray(A, (2,1,3,4));
+
+@inferred ArrayInterface.index_loops(A, (1:4, 2))
+A[Base.Slice(axes(A, 1)), 2]
+
+
+ArrayInterface.index_by_pointer(A, (Base.Slice(axes(A, 1)), Base.Slice(axes(A, 2))))
+ArrayInterface.index_by_pointer(A, (Base.Slice(axes(A, 1)), Base.Slice(axes(A, 2))))
+         , 1, 1)
+
+ArrayInterface.index_by_pointer(A, (1:2, 1:2, 1, 2))
+
+indexing_map(A, inds4)
+
+ArrayInterface.contiguous_axis_indicator(Ap)
+ArrayInterface.contiguous_axis_indicator(view(Ap, 1, :, :,1))
+ArrayInterface.contiguous_axis_indicator(view(A, :, :, :, 3))
+
+itr = StridedIterator(A)
+Av = @view(A[:, 2:4])
+
+collect(StridedIterator(Av))
+
+A = ones(Int, 4, 4,4,4);
+indexing_map(ones(Int, 4, 4,4,4), (1,1:4,1:4,1:4))
+
+src = pointer(A)
+dst = ArrayInterface.allocate_memory(A, 4)
+
+unsafe_copyto!(dst + m[1][1], src + m[1][2], 1)
+unsafe_copyto!(dst + m[2][1], src + m[2][2], 1)
+unsafe_copyto!(dst + m[3][1], src + m[3][2], 1)
+unsafe_copyto!(dst + m[4][1], src + m[4][2], 1)
+unsafe_wrap(Array, dst, (4,))
+
+
+unsafe_load(src, 1)
+unsafe_store!(dst, unsafe_load(src, 4), 2)
+unsafe_load(dst, 2)
+
+@btime ArrayInterface.unsafe_get_collection(A, (Base.Slice(axes(A, 1)), 2))
+


### PR DESCRIPTION
The goal of this is to finally integrate the indexing pipeline with a lot of the contributions from @chriselrod to this package. This is far from ready but I could use some input before moving forward with some things.  I'm mainly concerned about how to optimize iterating over linear indices and utilize `CPUPointer` in a generic way. I'll clarify by commenting on the code in this PR.

