### PR TITLE
Fix ambiguities on to_index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.4"
+version = "3.1.5"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -281,19 +281,20 @@ to_index(::MyIndexStyle, axis, arg) = ...
 ```
 """
 @propagate_inbounds to_index(axis, arg) = to_index(IndexStyle(axis), axis, arg)
-to_index(axis, arg::CartesianIndices{0}) = arg
+
 # Colons get converted to slices by `indices`
-to_index(::IndexStyle, axis, ::Colon) = indices(axis)
-@propagate_inbounds function to_index(::IndexStyle, axis, arg::Integer)
+to_index(::IndexLinear, axis, arg::Colon) = indices(axis)
+to_index(::IndexLinear, axis, arg::CartesianIndices{0}) = arg
+@propagate_inbounds function to_index(::IndexLinear, axis, arg::Integer)
     @boundscheck checkbounds(axis, arg)
     return Int(arg)
 end
-@propagate_inbounds function to_index(::IndexStyle, axis, arg::AbstractArray{Bool})
+@propagate_inbounds function to_index(::IndexLinear, axis, arg::AbstractArray{Bool})
     @boundscheck checkbounds(axis, arg)
     return @inbounds(axis[arg])
 end
 @propagate_inbounds function to_index(
-    ::IndexStyle,
+    ::IndexLinear,
     axis,
     arg::AbstractArray{I},
 ) where {I<:Integer}
@@ -303,7 +304,7 @@ end
     return arg
 end
 @propagate_inbounds function to_index(
-    ::IndexStyle,
+    ::IndexLinear,
     axis,
     arg::AbstractRange{I},
 ) where {I<:Integer}
@@ -312,8 +313,9 @@ end
     end
     return arg
 end
-function to_index(S::IndexStyle, axis, arg::Any)
-    throw(ArgumentError("invalid index: IndexStyle $S does not support indices of type $(typeof(arg))."))
+function to_index(s, axis, arg)
+    throw(ArgumentError("invalid index: IndexStyle $s does not support indices of " *
+                        "type $(typeof(arg)) for axis of type $(typeof(axis))."))
 end
 
 """

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -45,11 +45,13 @@ end
     @test @inferred(ArrayInterface.to_index(axis, 1:2)) === 1:2
     @test @inferred(ArrayInterface.to_index(axis, [1, 2])) == [1, 2]
     @test @inferred(ArrayInterface.to_index(axis, [true, false, false])) == [1]
+    @test @inferred(ArrayInterface.to_index(axis, CartesianIndices(()))) === CartesianIndices(())
 
     @test_throws BoundsError ArrayInterface.to_index(axis, 4)
     @test_throws BoundsError ArrayInterface.to_index(axis, 1:4)
     @test_throws BoundsError ArrayInterface.to_index(axis, [1, 2, 5])
     @test_throws BoundsError ArrayInterface.to_index(axis, [true, false, false, true])
+    @test_throws ArgumentError ArrayInterface.to_index(axis, error)
 end
 
 @testset "unsafe_reconstruct" begin


### PR DESCRIPTION
Using `IndexStyle` caused ambiguities in some rare cases and it's highly unlikely any native axis will be anything other than `IndexLinear`, so I replaced the `IndexStyle` args on the `to_index` methods to `IndexLinear`. 