### PR TITLE
Implement `broadcast_axis`

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -792,6 +792,7 @@ include("dimensions.jl")
 include("axes.jl")
 include("size.jl")
 include("stridelayout.jl")
+include("broadcast.jl")
 
 
 abstract type AbstractArray2{T,N} <: AbstractArray{T,N} end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -32,7 +32,7 @@ broadcast_axis(::BroadcastAxisDefault, x, y) = _broadcast_axis(BroadcastAxis(y),
 function _broadcast_axis(::BroadcastAxisDefault, x, y)
     return One():_combine_length(static_length(x), static_length(y))
 end
-_broadcast_axis(s::BroadcastAxis, x, y) = broadcasted_axis(s, x, y)
+_broadcast_axis(s::BroadcastAxis, x, y) = broadcast_axis(s, x, y)
 
 # we can use a similar trick as we do with `indices` where unequal sizes error and we just
 # keep the static value. However, axes can be unequal if one of them is `1` so we have to

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,0 +1,36 @@
+
+""" BroadcastAxis """
+abstract type BroadcastAxis end
+
+struct BroadcastAxisDefault <: BroadcastAxis end
+
+BroadcastAxis(x) = BroadcastAxis(typeof(x))
+BroadcastAxis(::Type{T}) where {T} = BroadcastAxisDefault()
+
+""" broadcast_axis(x, y) """
+broadcast_axis(x, y) = broadcast_axis(BroadcastAxis(x), x, y)
+# stagger default broadcasting in case y has something other than default
+broadcast_axis(::BroadcastAxisDefault, x, y) = _broadcast_axis(BroadcastAxis(y), x, y)
+function _broadcast_axis(::BroadcastAxisDefault, x, y)
+    return One():_combine_length(static_length(x), static_length(y))
+end
+_broadcast_axis(s::BroadcastAxis, x, y) = broadcasted_axis(s, x, y)
+_combine_length(::StaticInt{X}, ::StaticInt{Y}) where {X,Y} = static(_combine_length(X, Y))
+_combine_length(::StaticInt{X}, y::Int) where {X} = _combine_length(X, y)
+_combine_length(x::Int, ::StaticInt{Y}) where {Y} = _combine_length(x, Y)
+@inline function _combine_length(x::Int, y::Int)
+    if x === y
+        return x
+    elseif y === 1
+        return x
+    elseif x === 1
+        return y
+    else
+        _dimerr(x, y)
+    end
+end
+
+function _dimerr(@nospecialize(x), @nospecialize(y))
+    throw(DimensionMismatch("axes could not be broadcast to a common size; " *
+                            "got axes with lengths $(x) and $(y)"))
+end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,5 +1,9 @@
 
-""" BroadcastAxis """
+"""
+    BroadcastAxis
+
+An abstract trait that is used to determine how axes are combined when calling `broadcast_axis`.
+"""
 abstract type BroadcastAxis end
 
 struct BroadcastAxisDefault <: BroadcastAxis end
@@ -7,7 +11,21 @@ struct BroadcastAxisDefault <: BroadcastAxis end
 BroadcastAxis(x) = BroadcastAxis(typeof(x))
 BroadcastAxis(::Type{T}) where {T} = BroadcastAxisDefault()
 
-""" broadcast_axis(x, y) """
+"""
+    broadcast_axis(x, y)
+
+Broadcast axis `x` and `y` into a common space. The resulting axis should be equal in length
+to both `x` and `y` unless one has a length of `1`, in which case the longest axis will be
+equal to the output.
+
+```julia
+julia> ArrayInterface.broadcast_axis(1:10, 1:10)
+
+julia> ArrayInterface.broadcast_axis(1:10, 1)
+1:10
+
+```
+"""
 broadcast_axis(x, y) = broadcast_axis(BroadcastAxis(x), x, y)
 # stagger default broadcasting in case y has something other than default
 broadcast_axis(::BroadcastAxisDefault, x, y) = _broadcast_axis(BroadcastAxis(y), x, y)
@@ -15,9 +33,16 @@ function _broadcast_axis(::BroadcastAxisDefault, x, y)
     return One():_combine_length(static_length(x), static_length(y))
 end
 _broadcast_axis(s::BroadcastAxis, x, y) = broadcasted_axis(s, x, y)
-_combine_length(::StaticInt{X}, ::StaticInt{Y}) where {X,Y} = static(_combine_length(X, Y))
-_combine_length(::StaticInt{X}, y::Int) where {X} = _combine_length(X, y)
-_combine_length(x::Int, ::StaticInt{Y}) where {Y} = _combine_length(x, Y)
+
+# we can use a similar trick as we do with `indices` where unequal sizes error and we just
+# keep the static value. However, axes can be unequal if one of them is `1` so we have to
+# fall back to dynamic values in those cases
+_combine_length(x::StaticInt{X}, y::StaticInt{Y}) where {X,Y} = static(_combine_length(X, Y))
+_combine_length(x::StaticInt{X}, ::Int) where {X} = x
+_combine_length(x::StaticInt{1}, y::Int) = y
+_combine_length(x::StaticInt{1}, y::StaticInt{1}) = y
+_combine_length(x::Int, y::StaticInt{Y}) where {Y} = y
+_combine_length(x::Int, y::StaticInt{1}) = x
 @inline function _combine_length(x::Int, y::Int)
     if x === y
         return x

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -14,6 +14,7 @@ ArrayInterface.BroadcastAxis(::Type{DummyAxis}) = DummyBroadcast()
 
 ArrayInterface.broadcast_axis(::DummyBroadcast, x, y) = y
 
+@inferred(ArrayInterface.broadcast_axis(s1, s1)) === s1
 @inferred(ArrayInterface.broadcast_axis(s5, s5)) === s5
 @inferred(ArrayInterface.broadcast_axis(s5, s1)) === s5
 @inferred(ArrayInterface.broadcast_axis(s1, s5)) === s5
@@ -23,7 +24,7 @@ ArrayInterface.broadcast_axis(::DummyBroadcast, x, y) = y
 @inferred(ArrayInterface.broadcast_axis(d1, d5)) === d5
 @inferred(ArrayInterface.broadcast_axis(s1, d5)) === d5
 @inferred(ArrayInterface.broadcast_axis(d5, s1)) === d5
-@inferred(ArrayInterface.broadcast_axis(DummyAxis(), s5)) === s5
+@inferred(ArrayInterface.broadcast_axis(s5, DummyAxis())) === s5
 
 @test_throws DimensionMismatch ArrayInterface.broadcast_axis(s5, s4)
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,0 +1,13 @@
+
+s5 = static(1):static(5)
+s4 = static(1):static(4)
+s1 = static(1):static(1)
+d5 = static(1):5
+
+@inferred(ArrayInterface.broadcast_axis(s5, s5)) === s5
+@inferred(ArrayInterface.broadcast_axis(s5, s1)) === s5
+@inferred(ArrayInterface.broadcast_axis(s1, s5)) === s5
+@inferred(ArrayInterface.broadcast_axis(s5, d5)) === d5
+
+@test_throws DimensionMismatch ArrayInterface.broadcast_axis(s5, s4)
+

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -3,11 +3,27 @@ s5 = static(1):static(5)
 s4 = static(1):static(4)
 s1 = static(1):static(1)
 d5 = static(1):5
+d4 = static(1):static(4)
+d1 = static(1):static(1)
+
+struct DummyBroadcast <: ArrayInterface.BroadcastAxis end
+
+struct DummyAxis end
+
+ArrayInterface.BroadcastAxis(::Type{DummyAxis}) = DummyBroadcast()
+
+ArrayInterface.broadcast_axis(::DummyBroadcast, x, y) = y
 
 @inferred(ArrayInterface.broadcast_axis(s5, s5)) === s5
 @inferred(ArrayInterface.broadcast_axis(s5, s1)) === s5
 @inferred(ArrayInterface.broadcast_axis(s1, s5)) === s5
-@inferred(ArrayInterface.broadcast_axis(s5, d5)) === d5
+@inferred(ArrayInterface.broadcast_axis(s5, d5)) === s5
+@inferred(ArrayInterface.broadcast_axis(d5, s5)) === s5
+@inferred(ArrayInterface.broadcast_axis(d5, d1)) === d5
+@inferred(ArrayInterface.broadcast_axis(d1, d5)) === d5
+@inferred(ArrayInterface.broadcast_axis(s1, d5)) === d5
+@inferred(ArrayInterface.broadcast_axis(d5, s1)) === d5
+@inferred(ArrayInterface.broadcast_axis(DummyAxis(), s5)) === s5
 
 @test_throws DimensionMismatch ArrayInterface.broadcast_axis(s5, s4)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -716,3 +716,8 @@ end
 include("indexing.jl")
 include("dimensions.jl")
 
+@testset "broadcast" begin
+    include("broadcast.jl")
+end
+
+


### PR DESCRIPTION
This is essentially a formalization of [_bcs1](https://github.com/JuliaLang/julia/blob/86387a8587b7c3f6ecb28898d91365c2ae60a6a9/base/broadcast.jl#L495) that is called within the `combine_axes` function for broadcasting.

I'm sure we want to do some more stuff for broadcasting later, but for now I'm just trying to get some basic stuff in for combining axes. I'm not sure if we want the function that iteratively calls `broadcast_axis` to be `combine_axes`. We may want something more like `combine_layout` so that it can can account for reconstructing various types of sparsely populated arrays, which would involve more than just axes.