### PR TITLE
Layouts - combining array structure and indexing

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -661,6 +661,16 @@ _device(::False, ::Type{T}) where {T<:DenseArray} = CPUPointer()
 _device(::False, ::Type{T}) where {T} = CPUIndex()
 
 """
+    buffer(x)
+
+Return the raw buffer for `x`, stripping any additional info (structural, indexing,
+metadata, etc.).
+"""
+@inline buffer(x) = _buffer(has_parent(x), x)
+@inline _buffer(::True, x) = buffer(parent(x))
+_buffer(::False, x) = x
+
+"""
     defines_strides(::Type{T}) -> Bool
 
 Is strides(::T) defined? It is assumed that types returning `true` also return a valid

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -19,6 +19,8 @@ _int_or_static_int(x::Int) = StaticInt{x}
 _int(i::Integer) = Int(i)
 _int(i::StaticInt) = i
 
+static_ndims(x) = static(ndims(x))
+
 @static if VERSION >= v"1.7.0-DEV.421"
     using Base: @aggressive_constprop
 else
@@ -92,6 +94,7 @@ known_length(::Type{<:NamedTuple{L}}) where {L} = length(L)
 known_length(::Type{T}) where {T<:Slice} = known_length(parent_type(T))
 known_length(::Type{<:Tuple{Vararg{Any,N}}}) where {N} = N
 known_length(::Type{T}) where {Itr,T<:Base.Generator{Itr}} = known_length(Itr)
+known_length(::Type{T}) where {N,T<:AbstractCartesianIndex{N}} = N
 known_length(::Type{<:Number}) = 1
 function known_length(::Type{T}) where {T}
     if parent_type(T) <: T
@@ -661,16 +664,6 @@ _device(::False, ::Type{T}) where {T<:DenseArray} = CPUPointer()
 _device(::False, ::Type{T}) where {T} = CPUIndex()
 
 """
-    buffer(x)
-
-Return the raw buffer for `x`, stripping any additional info (structural, indexing,
-metadata, etc.).
-"""
-@inline buffer(x) = _buffer(has_parent(x), x)
-@inline _buffer(::True, x) = buffer(parent(x))
-_buffer(::False, x) = x
-
-"""
     defines_strides(::Type{T}) -> Bool
 
 Is strides(::T) defined? It is assumed that types returning `true` also return a valid
@@ -852,6 +845,7 @@ end
 end
 
 include("ranges.jl")
+include("layouts.jl")
 include("indexing.jl")
 include("dimensions.jl")
 include("axes.jl")

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -17,6 +17,7 @@ using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretAr
 _int_or_static_int(::Nothing) = Int
 _int_or_static_int(x::Int) = StaticInt{x}
 _int(i::Integer) = Int(i)
+_int(i::Int) = i
 _int(i::StaticInt) = i
 
 static_ndims(x) = static(ndims(x))

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -27,7 +27,6 @@ end
 Returns the type of the axes for `T`
 """
 axes_types(x) = axes_types(typeof(x))
-axes_types(::Type{T}) where {T<:Array} = Tuple{Vararg{OneTo{Int},ndims(T)}}
 function axes_types(::Type{T}) where {T}
     if parent_type(T) <: T
         return Tuple{Vararg{OptionallyStaticUnitRange{One,Int},ndims(T)}}
@@ -141,6 +140,7 @@ axes(A::Base.ReshapedArray, dim::Integer) = Base.axes(A, Int(dim))  # TODO imple
 
 Return a tuple of ranges where each range maps to each element along a dimension of `A`.
 """
+@inline axes(a::Array) = map(_as_index, size(a))
 @inline function axes(a::A) where {A}
     if parent_type(A) <: A
         return Base.axes(a)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -140,7 +140,9 @@ axes(A::Base.ReshapedArray, dim::Integer) = Base.axes(A, Int(dim))  # TODO imple
 
 Return a tuple of ranges where each range maps to each element along a dimension of `A`.
 """
-@inline axes(a::Array) = map(_as_index, size(a))
+@inline axes(a::Array) = _array_axes(size(a))
+@inline _array_axes(x::Tuple{Vararg{Int}}) = (static(1):first(x), _array_axes(tail(x))...)
+_array_axes(::Tuple{}) = ()
 @inline function axes(a::A) where {A}
     if parent_type(A) <: A
         return Base.axes(a)

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -37,7 +37,7 @@ from_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _from_sub_dims(A
     dim_i = 1
     for i in 1:ndims(A)
         p = I.parameters[i]
-        if argdims(A, p) > 0
+        if index_dims_out(A, p) > 0
             push!(out.args, :(StaticInt($dim_i)))
             dim_i += 1
         else
@@ -98,7 +98,7 @@ to_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _to_sub_dims(A, I)
     out = Expr(:tuple)
     n = 1
     for p in I.parameters
-        if argdims(A, p) > 0
+        if index_dims_out(A, p) > 0
             push!(out.args, :(StaticInt($n)))
         end
         n += 1

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -1,0 +1,140 @@
+
+_as_index(x) = x
+_as_index(x::Integer) = static(1):x
+_as_index(x::OneTo) = static(1):length(x)
+_as_index(x::StepRange) = OptionallyStaticStepRange(x)
+_as_index(x::UnitRange) = OptionallyStaticUnitRange(x)
+_as_index(x::OptionallyStaticRange) = x
+
+"""
+    StrideLayout(A)
+
+Produces an array whose elements correspond to the linear buffer position of `A`'s elements.
+"""
+struct StrideLayout{N,R,O1,S,A<:Tuple{Vararg{Any,N}}} <: AbstractArray2{Int,N}
+    rank::R
+    offset1::O1
+    strides::S
+    axes::A
+end
+
+offset1(x::StrideLayout) = getfield(x, :offset1)
+offsets(x::StrideLayout) = map(static_first, axes(x))
+axes(x::StrideLayout) = getfield(x, :axes)
+@inline function axes(x::StrideLayout{N}, i::Int) where {N}
+    if i > N
+        return static(1):1
+    else
+        return getfield(getfield(x, :axes), i)
+    end
+end
+@inline function axes(x::StrideLayout{N}, ::StaticInt{i}) where {N,i}
+    if i > N
+        return static(1):static(1)
+    else
+        return getfield(getfield(x, :axes), i)
+    end
+end
+strides(x::StrideLayout) = getfield(x, :strides)
+stride_rank(x::StrideLayout) = getfield(x, :rank)
+
+@inline function StrideLayout(x::DenseArray)
+    a = axes(x)
+    return StrideLayout(
+        stride_rank(x),
+        offset1(x),
+        size_to_strides(map(static_length, a), static(1)),
+        a
+    )
+end
+
+# TODO optimize this
+@inline function StrideLayout(x)
+    return StrideLayout(
+        stride_rank(x),
+        offset1(x),
+        strides(x),
+        axes(x)
+    )
+end
+
+##############
+### layout ###
+##############
+layout(x, i) = layout(x)
+layout(x, i::AbstractVector{<:Integer}) = _maybe_linear_layout(IndexStyle(x), x)
+layout(x, i::Integer) = _maybe_linear_layout(IndexStyle(x), x)
+layout(x, i::AbstractCartesianIndex{1}) = _maybe_linear_layout(IndexStyle(x), x)
+function layout(x, i::AbstractVector{AbstractCartesianIndex{1}})
+    return _maybe_linear_layout(IndexStyle(x), x)
+end
+_maybe_linear_layout(::IndexLinear, x) = _as_index(eachindex(x))
+_maybe_linear_layout(::IndexStyle, x) = layout(x)
+layout(x::StrideLayout) = x
+layout(x::LinearIndices) = x
+layout(x::CartesianIndices) = x
+function layout(x)
+    if defines_strides(x)
+        return StrideLayout(x)
+    else
+        return _layout_indices(IndexStyle(x), axes(x))
+    end
+end
+function layout(x::Transpose)
+    if defines_strides(x)
+        return StrideLayout(x)
+    else
+        return Transpose(layout(parent(x)))
+    end
+end
+function layout(x::Adjoint{T}) where {T<:Number}
+    if defines_strides(x)
+        return StrideLayout(x)
+    else
+        return Transpose(layout(parent(x)))
+    end
+end
+function layout(x::PermutedDimsArray{T,N,perm,iperm}) where {T,N,perm,iperm}
+    if defines_strides(x)
+        return StrideLayout(x)
+    else
+        p = layout(parent(x))
+        return PermutedDimsArray{eltype(p),ndims(p),perm, iperm,typeof(p)}(p)
+    end
+end
+function layout(x::SubArray)
+    if defines_strides(x)
+        return StrideLayout(x)
+    else
+        return @inbounds(view(layout(parent(x)), x.indices...))
+    end
+end
+_layout_indices(::IndexStyle, axs) = CartesianIndices(axs)
+_layout_indices(::IndexLinear, axs) = LinearIndices(axs)
+
+"""
+    buffer(x)
+
+Return the raw buffer for `x`, stripping any additional info (structural, indexing,
+metadata, etc.).
+"""
+buffer(x) = x
+@inline buffer(x::PermutedDimsArray) = buffer(parent(x))
+@inline buffer(x::Transpose) = buffer(parent(x))
+@inline buffer(x::Adjoint) = buffer(parent(x))
+@inline buffer(x::SubArray) = buffer(parent(x))
+
+
+""" allocate_memory(::AbstractDevice, ::Type{T}, length::Union{StaticInt,Int}) """
+allocate_memory(::CPUPointer, ::Type{T}, ::StaticInt{N}) where {T,N} = Ref{NTuple{N,T}}
+allocate_memory(::CPUPointer, ::Type{T}, n::Int) where {T} = Vector{T}(undef, n)
+allocate_memory(::CPUTuple, ::Type{T}, ::StaticInt{N}) where {T,N} = Ref{NTuple{N,T}}
+
+
+""" dereference(::AbstractDevice, x) """
+dereference(::CPUPointer, x) = x
+dereference(::CPUTuple, x::Ref) = x[]
+
+""" initialize(data, layout) """
+function initialize end
+

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -1,6 +1,5 @@
 
 _as_index(x) = x
-_as_index(x::Integer) = static(1):x
 _as_index(x::OneTo) = static(1):length(x)
 _as_index(x::StepRange) = OptionallyStaticStepRange(x)
 _as_index(x::UnitRange) = OptionallyStaticUnitRange(x)

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -266,6 +266,22 @@ end
 
 @propagate_inbounds function Base.getindex(
     r::OptionallyStaticUnitRange,
+    s::StepRange{T}
+) where {T<:Integer}
+
+    @boundscheck checkbounds(r, s)
+    if T === Bool
+        range(first(s) ? first(r) : last(r), step=oneunit(eltype(r)), length = Int(last(s)))
+    else
+        start = first(r) + s.start - 1
+        st = step(s)
+        stop = ((length(s) - 1) * st) + start
+        return OptionallyStaticStepRange(start, st, stop)
+    end
+end
+
+@propagate_inbounds function Base.getindex(
+    r::OptionallyStaticUnitRange,
     s::AbstractUnitRange{<:Integer},
 )
     @boundscheck checkbounds(r, s)

--- a/src/size.jl
+++ b/src/size.jl
@@ -20,6 +20,7 @@ function size(a::A) where {A}
         return size(parent(a))
     end
 end
+size(x::Array) = Base.size(x)
 #size(a::AbstractVector) = (size(a, One()),)
 
 size(x::SubArray) = eachop(_sub_size, to_parent_dims(x), x.indices)

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -46,6 +46,9 @@ Returns the offset of the linear indices for `x`.
 offset1(x) = _offset1(has_parent(x), x)
 _offset1(::True, x) = offset1(parent(x))
 _offset1(::False, x) = static(1)
+function offset1(x::SubArray)
+    return unsafe_get_element(layout(parent(x)), NDIndex(map(static_first, x.indices)))
+end
 
 """
     contiguous_axis(::Type{T}) -> StaticInt{N}

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -147,8 +147,8 @@ end
     @test @inferred(ArrayInterface.size(y')) == (1, size(parent(x), 1))
     @test @inferred(axes(x, first(d))) == axes(parent(x), 1)
     @test strides(x, :x) == ArrayInterface.strides(parent(x))[1]
-    @test @inferred(ArrayInterface.axes_types(x, static(:x))) <: Base.OneTo{Int}
-    @test ArrayInterface.axes_types(x, :x) <: Base.OneTo{Int}
+    @test @inferred(ArrayInterface.axes_types(x, static(:x))) <: AbstractUnitRange{Int}
+    @test ArrayInterface.axes_types(x, :x) <: AbstractUnitRange{Int}
     @test @inferred(ArrayInterface.axes_types(LinearIndices{2,NTuple{2,Base.OneTo{Int}}})) <: NTuple{2,Base.OneTo{Int}}
     CI = CartesianIndices{2,Tuple{Base.OneTo{Int},UnitRange{Int}}}
     @test @inferred(ArrayInterface.axes_types(CI, static(1))) <: Base.OneTo{Int}

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -8,15 +8,14 @@ using ArrayInterface: NDIndex
   0.047 ns (0 allocations: 0 bytes)
 =#
 
-#=
-@testset "argdims" begin
-    @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), (1, CartesianIndex(1,2)))) === static((0, 2))
-    @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), (1, [CartesianIndex(1,2), CartesianIndex(1,3)]))) === static((0, 2))
-    @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), (1, CartesianIndex((2,2))))) === static((0, 2))
-    @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), (CartesianIndex((2,2)), :, :))) === static((2, 1, 1))
-    @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), Vector{Int})) === static(1)
+@testset "index_dims_in" begin
+    @test @inferred(ArrayInterface.index_dims_in(IndexLinear(), (1, CartesianIndex(1,2)))) === static((1, 2))
+    @test @inferred(ArrayInterface.index_dims_in(IndexLinear(), (1, [CartesianIndex(1,2), CartesianIndex(1,3)]))) === static((1, 2))
+    @test @inferred(ArrayInterface.index_dims_in(IndexLinear(), (1, CartesianIndex((2,2))))) === static((1, 2))
+    @test @inferred(ArrayInterface.index_dims_in(IndexLinear(), (CartesianIndex((2,2)), :, :))) === static((2, 1, 1))
+    @test @inferred(ArrayInterface.index_dims_in(IndexLinear(), Vector{Int})) === static(1)
 end
-=#
+
 @testset "to_index" begin
     axis = 1:3
     @test @inferred(ArrayInterface.to_index(axis, 1)) === 1
@@ -197,9 +196,10 @@ end
 end
 
 @testset "stride indexing" begin
-    x = Array{Int,3}(undef, (4,4,4))
-    x[:] = 1:length(x)
-    p = PermutedDimsArray(x, (3, 1, 2))
+    x = Array{Int,3}(undef, (4,4,4));
+    x[:] = 1:length(x);
+    p = PermutedDimsArray(x, (3, 1, 2));
+    v = view(x, :, 2, :);
     @test ArrayInterface.getindex(x, :, :, :) == Base.getindex(x, :, :, :)
     @test ArrayInterface.getindex(x, 3, :, :) == Base.getindex(x, 3, :, :)
     @test ArrayInterface.getindex(x, :, 3, :) == Base.getindex(x, :, 3, :)
@@ -207,5 +207,6 @@ end
     @test ArrayInterface.getindex(p, :, :, :) == Base.getindex(p, :, :, :)
     @test ArrayInterface.getindex(p, 3, :, :) == Base.getindex(p, 3, :, :)
     @test ArrayInterface.getindex(p, :, 3, :) == Base.getindex(p, :, 3, :)
+    @test ArrayInterface.getindex(v, :, :) == getindex(v, :, :)
 end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -24,9 +24,11 @@ end
     @test @inferred(ArrayInterface.to_index(axis, [true, false, false])) == [1]
     @test @inferred(ArrayInterface.to_index(axis, CartesianIndices(()))) === CartesianIndices(())
 
+    #=
     x = LinearIndices((static(0):static(3),static(3):static(5),static(-2):static(0)));
     @test @inferred(ArrayInterface.to_index(x, NDIndex((0, 3, -2)))) === 1
     @test @inferred(ArrayInterface.to_index(x, NDIndex(static(0), static(3), static(-2)))) === static(1)
+    =#
 
     @test_throws BoundsError ArrayInterface.to_index(axis, 4)
     @test_throws BoundsError ArrayInterface.to_index(axis, 1:4)
@@ -115,7 +117,7 @@ end
     # which returns a UnitRange. Instead we try to preserve axes if at all possible so the
     # values are the same but it's still wrapped in LinearIndices struct
     @test @inferred(ArrayInterface.getindex(LinearIndices((3,)), 1:2)) == 1:2
-    @test @inferred(ArrayInterface.getindex(LinearIndices((3,)), 1:2:3)) === 1:2:3
+    @test @inferred(ArrayInterface.getindex(LinearIndices((3,)), 1:2:3)) == 1:2:3
     @test_throws BoundsError ArrayInterface.getindex(LinearIndices((3,)), 2:4)
     @test_throws BoundsError ArrayInterface.getindex(CartesianIndices((3,)), 2, 2)
     #   ambiguity btw cartesian indexing and linear indexing in 1d when
@@ -124,8 +126,8 @@ end
     #@test_throws ArgumentError Base._sub2ind((1:3,), 2)
     #@test_throws ArgumentError Base._ind2sub((1:3,), 2)
     x = Array{Int,2}(undef, (2, 2))
-    ArrayInterface.unsafe_set_index!(x, 1, (2, 2))
-    @test ArrayInterface.unsafe_get_index(x, (2, 2)) === 1
+    ArrayInterface.unsafe_setindex!(x, 1, (2, 2))
+    @test ArrayInterface.unsafe_getindex(x, (2, 2)) === 1
 
     # FIXME @test_throws MethodError ArrayInterface.unsafe_set_element!(x, 1, (:x, :x))
     # FIXME @test_throws MethodError ArrayInterface.unsafe_get_element(x, (:x, :x))
@@ -156,7 +158,7 @@ end
     @test @inferred(ArrayInterface.getindex(cartesian, cartesian)) == cartesian
     @test @inferred(ArrayInterface.getindex(cartesian, vec(cartesian))) == vec(cartesian)
     @test @inferred(ArrayInterface.getindex(linear, 2:3)) === 2:3
-    @test @inferred(ArrayInterface.getindex(linear, 3:-1:1)) === 3:-1:1
+    @test @inferred(ArrayInterface.getindex(linear, 3:-1:1)) == 3:-1:1
     @test_throws BoundsError ArrayInterface.getindex(linear, 4:13)
 end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -8,6 +8,7 @@ using ArrayInterface: NDIndex
   0.047 ns (0 allocations: 0 bytes)
 =#
 
+#=
 @testset "argdims" begin
     @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), (1, CartesianIndex(1,2)))) === static((0, 2))
     @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), (1, [CartesianIndex(1,2), CartesianIndex(1,3)]))) === static((0, 2))
@@ -15,7 +16,7 @@ using ArrayInterface: NDIndex
     @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), (CartesianIndex((2,2)), :, :))) === static((2, 1, 1))
     @test @inferred(ArrayInterface.argdims(ArrayInterface.DefaultArrayStyle(), Vector{Int})) === static(1)
 end
-
+=#
 @testset "to_index" begin
     axis = 1:3
     @test @inferred(ArrayInterface.to_index(axis, 1)) === 1

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -195,3 +195,16 @@ end
     end
 end
 
+@testset "stride indexing" begin
+    x = Array{Int,3}(undef, (4,4,4))
+    x[:] = 1:length(x)
+    p = PermutedDimsArray(x, (3, 1, 2))
+    @test ArrayInterface.getindex(x, :, :, :) == Base.getindex(x, :, :, :)
+    @test ArrayInterface.getindex(x, 3, :, :) == Base.getindex(x, 3, :, :)
+    @test ArrayInterface.getindex(x, :, 3, :) == Base.getindex(x, :, 3, :)
+
+    @test ArrayInterface.getindex(p, :, :, :) == Base.getindex(p, :, :, :)
+    @test ArrayInterface.getindex(p, 3, :, :) == Base.getindex(p, 3, :, :)
+    @test ArrayInterface.getindex(p, :, 3, :) == Base.getindex(p, :, 3, :)
+end
+


### PR DESCRIPTION
This is the first big step towards solving a lot of the recent issues I've created and also further combines the stride traits with the rest of ArrayInterface.jl.

The conceptual piece here is the concept of a "layout" (if you have a better name feel free to recommend it b/c I hate naming things). The idea is that we need to propagate information about an array's structure _and_ anything it wraps when accessing collections of its elements so I've included `layout(::AbstractArray, index)`. The return value of `layout` is intended to be the most appropriate iterator for accessing the _memory_ that corresponds to `index`. Note that this is different than `eachindex`, `LinearIndices`, or `CartesianIndices`, which are meant to directly index the array they are called on. This is why I've also included `buffer` for extracting the most direct reference to an array's memory. This PR is strictly focusing on the stride array layout, but I've played around with a bunch of different ways this could be generalized to other situations (sparse, lazy stacked). For and idea of how we are already circling this in Base, you could look at [`SCartesianIndex2`](https://github.com/JuliaLang/julia/blob/c87d85feaf547f763c5dee64c1be163b02df210d/base/reinterpretarray.jl#L202) for reinterpreted arrays.

Currently `layout` is very basic and geared towards arrays with strides. If linear indexing is performed, then we see if the array is `IndexLinear`, otherwise we construct an instance of `StrideIndices`. I've also changed what the flow into `to_indices` is. Instead of passing the indexed array the result of layout is passed. This works out pretty nicely because if you know the layout of an array you also know the axes so I've mostly done some cleaning up there.

Here are some very basic benchmarks (with the array print out removed).

```julia
julia> x = ones(4,4,4);

julia> @btime ArrayInterface.getindex(x, 3, :, :)
  74.965 ns (2 allocations: 224 bytes)

julia> @btime getindex(x, 3, :, :)
  347.114 ns (4 allocations: 288 bytes)

julia> @btime ArrayInterface.getindex(x, :, 3, :)
  69.938 ns (2 allocations: 224 bytes)

julia> @btime getindex(x, :, 3, :)
  404.116 ns (7 allocations: 352 bytes)

julia> @btime ArrayInterface.getindex(x, :, :, 3)
  73.510 ns (2 allocations: 224 bytes)

julia> @btime getindex(x, :, :, 3)
  276.487 ns (4 allocations: 288 bytes)
```

I also wanted to see how much of a difference was due to cleaning up the overall pipeline, and how much was due to using strides. So I compared comparable spots in the base call to indexing a collection and ArrayInterface.jl

```julia
inds = Base.to_indices(x, (:, :, :))
@btime inner_index(x, inds)
@btime inner_index_base(x, inds)

julia> @btime inner_index(x, inds)
  119.776 ns (1 allocation: 624 bytes)

julia> @btime inner_index_base(x, inds)
  238.631 ns (5 allocations: 688 bytes)

``` 

None of this is combining slices or taking advantage of any fancy memory management, just turning multidim indexing into linear indexing with strides.

I'll continue to put together more robust tests, but I wanted know if/how you'd like this to work with StrideArrays.jl and LoopVectorization.jl. This was discussed in some detail in #94 (which this is replacing). I was leaning towards having something like vaguely akin to...

```julia
function unsafe_get_collection(A, layout, inds)
    axs = to_axes(lyt, inds)
    dst = similar(A, axs)
    map(Base.unsafe_length, axes(dst)) == map(Base.unsafe_length, axs) || Base.throw_checksize_error(dst, axs)
    # usually a generated function, don't allow it to impact inference result
    Ab, Aptr = buffer_pointer(A)
    dstb, dstptr = buffer_pointer(A)
    GC.@preserve Ab dstb copyto!(dstptr, layout(dstptr, :), Aptr, view(lyt, inds...))
    return dst
end
```
...and then whatever buffers and pointers are produced could control dispatch for more optimized memory management based on hardware.

