### PR TITLE
Fix ReinterpretArray's definition of strides

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -650,12 +650,18 @@ end
 
         Ar2c = reinterpret(reshape, Complex{Float64}, view(rand(2, 5, 7), :, 2:4, 3:5));
         @test @inferred(ArrayInterface.strides(Ar2c)) === (StaticInt(1), 5)
+        Ar2c_static = reinterpret(reshape, Complex{Float64}, view(@MArray(rand(2, 5, 7)), :, 2:4, 3:5));
+        @test @inferred(ArrayInterface.strides(Ar2c_static)) === (StaticInt(1), StaticInt(5))
 
         Ac2r = reinterpret(reshape, Float64, view(rand(ComplexF64, 5, 7), 2:4, 3:6));
         @test @inferred(ArrayInterface.strides(Ac2r)) === (StaticInt(1), StaticInt(2), 10)
+        Ac2r_static = reinterpret(reshape, Float64, view(@MMatrix(rand(ComplexF64, 5, 7)), 2:4, 3:6));
+        @test @inferred(ArrayInterface.strides(Ac2r_static)) === (StaticInt(1), StaticInt(2), StaticInt(10))
       
         Ac2t = reinterpret(reshape, Tuple{Float64,Float64}, view(rand(ComplexF64, 5, 7), 2:4, 3:6));
         @test @inferred(ArrayInterface.strides(Ac2t)) === (StaticInt(1), 5)
+        Ac2t_static = reinterpret(reshape, Tuple{Float64,Float64}, view(@MMatrix(rand(ComplexF64, 5, 7)), 2:4, 3:6));
+        @test @inferred(ArrayInterface.strides(Ac2t_static)) === (StaticInt(1), StaticInt(5))
 
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -647,6 +647,16 @@ end
         @test @inferred(ArrayInterface.dense_dims(view(Sr2,:,2))) === (True(),)
         @test @inferred(ArrayInterface.dense_dims(view(Sr2,:,2:3))) === (True(),True())
         @test @inferred(ArrayInterface.dense_dims(view(Sr2,2:3,:))) === (True(),False())
+
+        Ar2c = reinterpret(reshape, Complex{Float64}, view(rand(2, 5, 7), :, 2:4, 3:5));
+        @test @inferred(ArrayInterface.strides(Ar2c)) === (StaticInt(1), 5)
+
+        Ac2r = reinterpret(reshape, Float64, view(rand(ComplexF64, 5, 7), 2:4, 3:6));
+        @test @inferred(ArrayInterface.strides(Ac2r)) === (StaticInt(1), StaticInt(2), 10)
+      
+        Ac2t = reinterpret(reshape, Tuple{Float64,Float64}, view(rand(ComplexF64, 5, 7), 2:4, 3:6));
+        @test @inferred(ArrayInterface.strides(Ac2t)) === (StaticInt(1), 5)
+
     end
 end
 


### PR DESCRIPTION
To be inline with ArrayInterface's meaning (i.e., about memory layout), rather than use [size_of_strides](https://github.com/JuliaLang/julia/blob/75c4f5562a0cd83f47c5695caee33c45630e76fc/base/reinterpretarray.jl#L161) like Base Julia.
Using `size_to_strides` causes LoopVectorization to get incorrect answers when `reinterpret`ing `SubArray`s.