### PR TITLE
Improve single element indexing (and other quality of life improvements)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.9"
+version = "3.1.10"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -842,10 +842,10 @@ end
 end
 
 include("ranges.jl")
-include("indexing.jl")
 include("dimensions.jl")
 include("axes.jl")
 include("size.jl")
+include("indexing.jl")
 include("stridelayout.jl")
 include("broadcast.jl")
 

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -16,8 +16,6 @@ using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretAr
 ## utilites for internal use only ##
 _int_or_static_int(::Nothing) = Int
 _int_or_static_int(x::Int) = StaticInt{x}
-_int(i::Integer) = Int(i)
-_int(i::StaticInt) = i
 
 @static if VERSION >= v"1.7.0-DEV.421"
     using Base: @aggressive_constprop

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -37,11 +37,9 @@ function axes_types(::Type{T}) where {T}
 end
 axes_types(::Type{LinearIndices{N,R}}) where {N,R} = R
 axes_types(::Type{CartesianIndices{N,R}}) where {N,R} = R
-function axes_types(::Type{T}) where {T<:VecAdjTrans}
-    return Tuple{OptionallyStaticUnitRange{One,One},axes_types(parent_type(T), One())}
-end
-function axes_types(::Type{T}) where {T<:MatAdjTrans}
-    return eachop_tuple(_get_tuple, to_parent_dims(T), axes_types(parent_type(T)))
+function axes_types(::Type{T}) where {T<:Union{Adjoint,Transpose}}
+    P = parent_type(T)
+    return Tuple{axes_types(P, static(2)), axes_types(P, static(1))}
 end
 function axes_types(::Type{T}) where {T<:PermutedDimsArray}
     return eachop_tuple(_get_tuple, to_parent_dims(T), axes_types(parent_type(T)))

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -293,7 +293,7 @@ Base.show(io::IO, x::LazyAxis{N}) where {N} = print(io, "LazyAxis{$N}($(parent(x
     lazy_axes(x)
 
 Produces a tuple of axes where each axis is constructed lazily. If an axis of `x` is already
-constructed or its entire structure is known at compile time it is constructed eagerly.
+constructed or it is simply retrieved.
 """
 @generated function lazy_axes(x::X) where {X}
     Expr(:block,
@@ -301,5 +301,9 @@ constructed or its entire structure is known at compile time it is constructed e
          Expr(:tuple, [:(LazyAxis{$dim}(x)) for dim in 1:ndims(X)]...)
     )
 end
-lazy_axes(x, ::Colon) = LazyAxis{:}(x)
+lazy_axes(x::LinearIndices) = axes(x)
+lazy_axes(x::CartesianIndices) = axes(x)
+@inline lazy_axes(x::MatAdjTrans) = reverse(lazy_axes(parent(x)))
+@inline lazy_axes(x::VecAdjTrans) = (LazyAxis{1}(x), first(lazy_axes(parent(x))))
+@inline lazy_axes(x::PermutedDimsArray) = permute(lazy_axes(parent(x)), to_parent_dims(A))
 

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -217,6 +217,8 @@ Base.keys(x::LazyAxis) = keys(parent(x))
 
 Base.IndexStyle(::Type{T}) where {T<:LazyAxis} = IndexStyle(parent_type(T))
 
+can_change_size(::Type{LazyAxis{N,P}}) where {N,P} = can_change_size(P)
+
 known_first(::Type{T}) where {T<:LazyAxis} = known_first(parent_type(T))
 
 known_length(::Type{LazyAxis{N,P}}) where {N,P} = known_size(P, N)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -133,6 +133,21 @@ function axes(a::A, dim::Integer) where {A}
         return axes(parent(a), to_parent_dims(A, dim))
     end
 end
+function axes(A::CartesianIndices{N}, dim::Integer) where {N}
+    if dim > N
+        return static(1):static(1)
+    else
+        return getfield(axes(A), Int(dim))
+    end
+end
+function axes(A::LinearIndices{N}, dim::Integer) where {N}
+    if dim > N
+        return static(1):static(1)
+    else
+        return getfield(axes(A), Int(dim))
+    end
+end
+
 axes(A::SubArray, dim::Integer) = Base.axes(A, Int(dim))  # TODO implement ArrayInterface version
 axes(A::ReinterpretArray, dim::Integer) = Base.axes(A, Int(dim))  # TODO implement ArrayInterface version
 axes(A::Base.ReshapedArray, dim::Integer) = Base.axes(A, Int(dim))  # TODO implement ArrayInterface version
@@ -261,7 +276,7 @@ Base.to_shape(x::LazyAxis) = length(x)
     if known_first(x) === nothing || known_last(x) === nothing
         return checkindex(Bool, parent(x), i)
     else  # everything is static so we don't have to retrieve the axis
-        return ((known_first(x) > i) && (known_last(x) < i))
+        return (!(known_first(x) > i) || !(known_last(x) < i))
     end
 end
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -190,16 +190,13 @@ function dimnames(::Type{T}) where {T<:SubArray}
     return eachop(dimnames, to_parent_dims(T), parent_type(T))
 end
 
-_to_int(x::Integer) = Int(x)
-_to_int(x::StaticInt) = x
-
 """
     to_dims(::Type{T}, dim) -> Integer
 
 This returns the dimension(s) of `x` corresponding to `d`.
 """
 to_dims(x, dim) = to_dims(typeof(x), dim)
-to_dims(::Type{T}, dim::Integer) where {T} = _to_int(dim)
+to_dims(::Type{T}, dim::Integer) where {T} = canonicalize(dim)
 to_dims(::Type{T}, dim::Colon) where {T} = dim
 function to_dims(::Type{T}, dim::StaticSymbol) where {T}
     i = find_first_eq(dim, dimnames(T))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -216,31 +216,8 @@ end
 end
 @propagate_inbounds function _to_indices(::StaticInt{N}, A, axs::Tuple, args::Tuple) where {N}
     axes_front, axes_tail = Base.IteratorsMD.split(axs, Val(N))
-    return _to_multi_indices(A, axes_front, axes_tail, first(args), _maybe_tail(args))
+    return (to_index(_layout(IndexStyle(A), axes_front), first(args)), to_indices(A, axes_tail, _maybe_tail(args))...)
 end
-@propagate_inbounds function _to_multi_indices(
-    A,
-    axes_front::Tuple,
-    axes_tail::Tuple,
-    arg::Union{LinearIndices,CartesianIndices},
-    args::Tuple
-)
-    return (to_indices(A, axes_front, axes(arg))..., to_indices(A, axes_tail, args)...,)
-end
-@propagate_inbounds function _to_multi_indices(
-    A,
-    axes_front::Tuple,
-    axes_tail::Tuple,
-    arg::AbstractCartesianIndex,
-    args::Tuple
-)
-    return (map(to_index, axes_front, Tuple(arg))..., to_indices(A, axes_tail, args)...)
-end
-
-@propagate_inbounds function _to_multi_indices(A, f::Tuple, l::Tuple, arg, args::Tuple)
-    return (to_index(_layout(IndexStyle(A), f), arg), to_indices(A, l, args)...)
-end
-
 @propagate_inbounds function to_indices(A, axs::Tuple, args::Tuple{})
     @boundscheck if length(first(axs)) != 1
         error("Cannot drop dimension of size $(length(first(axs))).")
@@ -253,7 +230,6 @@ end
 to_indices(A, axs::Tuple{}, args::Tuple{}) = ()
 _maybe_tail(::Tuple{}) = ()
 _maybe_tail(x::Tuple) = tail(x)
-
 
 """
     to_index([::IndexStyle, ]axis, arg) -> index

--- a/src/ndindex.jl
+++ b/src/ndindex.jl
@@ -57,7 +57,7 @@ end
 _flatten(i::StaticInt{N}) where {N} = (i,)
 _flatten(i::Integer) = (Int(i),)
 _flatten(i::Base.AbstractCartesianIndex) = _flatten(Tuple(i)...)
-@inline _flatten(i::Integer, I...) = (_int(i), _flatten(I...)...)
+@inline _flatten(i::Integer, I...) = (canonicalize(i), _flatten(I...)...)
 @inline function _flatten(i::Base.AbstractCartesianIndex, I...)
     return (_flatten(Tuple(i)...)..., _flatten(I...)...)
  end

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -98,9 +98,20 @@ struct OptionallyStaticUnitRange{F<:Integer,L<:Integer} <: AbstractUnitRange{Int
     end
 end
 
-Base.first(r::OptionallyStaticUnitRange) = r.start
-Base.step(::OptionallyStaticUnitRange) = StaticInt(1)
-Base.last(r::OptionallyStaticUnitRange) = r.stop
+function Base.first(r::OptionallyStaticUnitRange)::Int
+    if known_first(r) === nothing
+        return r.start
+    else
+        return known_first(r)
+    end
+end
+function Base.last(r::OptionallyStaticUnitRange)::Int
+    if known_last(r) === nothing
+        return r.stop
+    else
+        return known_last(r)
+    end
+end
 
 known_first(::Type{<:OptionallyStaticUnitRange{StaticInt{F}}}) where {F} = F
 known_step(::Type{<:OptionallyStaticUnitRange}) = 1
@@ -186,9 +197,27 @@ end
         end
     end
 end
-Base.first(r::OptionallyStaticStepRange) = r.start
-Base.step(r::OptionallyStaticStepRange) = r.step
-Base.last(r::OptionallyStaticStepRange) = r.stop
+function Base.first(r::OptionallyStaticStepRange)::Int
+    if known_first(r) === nothing
+        return r.start
+    else
+        return known_first(r)
+    end
+end
+function Base.step(r::OptionallyStaticStepRange)::Int
+    if known_step(r) === nothing
+        return r.step
+    else
+        return known_step(r)
+    end
+end
+function Base.last(r::OptionallyStaticStepRange)::Int
+    if known_last(r) === nothing
+        return r.stop
+    else
+        return known_last(r)
+    end
+end
 
 known_first(::Type{<:OptionallyStaticStepRange{StaticInt{F}}}) where {F} = F
 known_step(::Type{<:OptionallyStaticStepRange{<:Any,StaticInt{S}}}) where {S} = S
@@ -425,6 +454,11 @@ end
 end
 
 Base.:(-)(r::OptionallyStaticRange) = -static_first(r):-static_step(r):-static_last(r)
+
+Base.reverse(r::OptionallyStaticUnitRange) = static_last(r):static(-1):static_first(r)
+function Base.reverse(r::OptionallyStaticStepRange)
+    return OptionallyStaticStepRange(static_last(r), -static_step(r), static_first(r))
+end
 
 function Base.show(io::IO, r::OptionallyStaticRange)
     print(io, first(r))

--- a/src/size.jl
+++ b/src/size.jl
@@ -53,6 +53,7 @@ size(A::AbstractRange) = (static_length(A),)
 Returns the size of `A` along dimension `dim`.
 """
 size(a, dim) = size(a, to_dims(a, dim))
+size(a::Array, dim::Integer) = Base.arraysize(a, convert(Int, dim))
 function size(a::A, dim::Integer) where {A}
     if parent_type(A) <: A
         len = known_size(A, dim)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -759,6 +759,23 @@ end
     end
 end
 
+
+@testset "axes" begin
+    A = zeros(3,4,5);
+    Ap = @view(PermutedDimsArray(A, (3,1,2))[:,1:2,1])';
+
+    axs = @inferred(ArrayInterface.axes(Ap))
+    lzaxs = @inferred(ArrayInterface.lazy_axes(Ap))
+    axis = axs[2]
+    lzaxis = lzaxs[2]
+
+    @test map(parent, lzaxs) === axs
+    @test @inferred(first(lzaxis)) === first(axis)
+    @test @inferred(lzaxis[2]) === axis[2]
+    @test @inferred(lzaxis[1:2:5]) === axis[1:2:5]
+    @test @inferred(lzaxis[1:2]) === axis[1:2]
+end
+
 include("ndindex.jl")
 include("indexing.jl")
 include("dimensions.jl")


### PR DESCRIPTION
While working on layouts for #141 I realized that unless `getindex` was skipped (e.g., directly calling `unsafe_getindex`) than element-wise indexing was a lot slower. I approached this from a lot of different angles (some of which will probably come up in another PR still), but the issue appears to be due to the compiler not knowing to elide reconstruction of something like `Tuple{Int,Int}`, despite not undergoing any change throughout `to_indices`. So I'll start with the fix I had for that.

# Canonical Indexing Types
I chose the name because I saw a similar concept in [LoopVectorization](https://github.com/JuliaSIMD/LoopVectorization.jl/blob/2fdb50f8685c85f95e3292b137c0a8f3a9ca6c48/src/modeling/graphs.jl#L873). In `to_indices(A, args::Tuple)` each element of `args` is checked to see if it is a canonical indexing type up front, avoiding recursive reconstruction of the tuple of indexers. This check is performed by `is_canonical`, resulting in the following improvement:

```julia
x = ones(4,4,4);

#  current version
julia> @btime ArrayInterface.getindex($x, 3, 3, 3)
  4.566 ns (0 allocations: 0 bytes)
1.0

#  new version
julia> @btime ArrayInterface.getindex($x, 3, 3, 3)
  1.755 ns (0 allocations: 0 bytes)
1.0

# base version
julia> @btime getindex($x, 3, 3, 3)
  1.756 ns (0 allocations: 0 bytes)
1.0

```

I've also expanded on the number of types that are considered "canonical" indexers from that of base (e.g., we don't ever need to change `OptionallyStaticUnitRange`), so there may also be some (_very small_) improvements on indexing collection.
I think we could still squeeze some more performance out of this by avoiding construction of axes for types where the conversion to the canonical state is known already.
This is kind of the idea behind `canonicalize(x)`, which converts `x` to a canonical indexer and helped clean up some internal code that does the same thing.
I'm probably going to work on that optimization in another PR b/c it will probably require some involved work on the internal mechanics of `to_indices`.
For now we at least are as fast as Base.

# LazyAxis

A lot of array traits can be derived from looking an array's axes.
Many arrays don't have fully constructed axes stored with them, meaning we usually spend some unnecessary time composing an axis to just find out its size or offset.
Using `lazy_axes` we can sometimes avoid these costs.

For example, we can avoid the cost of retrieving size information for an `Array`.

```julia
axes_map_first(x) = map(first, ArrayInterface.axes(x))
lazy_axes_map_first(x) = map(first, ArrayInterface.lazy_axes(x))

julia> @btime axes_map_first($x)
  1.754 ns (0 allocations: 0 bytes)
(1, 1, 1)

julia> @btime lazy_axes_map_first($x)
  0.046 ns (0 allocations: 0 bytes)
(1, 1, 1)
```

Much of this improvement is lost when we size information has to be called by both approaches.
```julia
axes_map_last(x) = map(last, ArrayInterface.axes(x))
lazy_axes_map_last(x) = map(last, ArrayInterface.lazy_axes(x))

julia> @btime axes_map_last($x)
  1.608 ns (0 allocations: 0 bytes)
(4, 4, 4)

julia> @btime lazy_axes_map_last($x)
  1.470 ns (0 allocations: 0 bytes)
(4, 4, 4)
```

I've started putting this in several places and it looks like it either does as well as the eager method or improves on it.
I could probably be a little more exhaustive with improving the performance of this, but figured it was helpful enough to include as is right now.

One final note, I'm aware that I've added a bunch of messy code for bounds checking. I'm going to clean this up when I fine tune `to_indices` later on.

