### PR TITLE
BigFloat/BigInt are not mutable (as arrays)

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -133,6 +133,8 @@ end
 ismutable(::Type{<:AbstractRange}) = false
 ismutable(::Type{<:AbstractDict}) = true
 ismutable(::Type{<:Base.ImmutableDict}) = false
+ismutable(::Type{BigFloat}) = false
+ismutable(::Type{BigInt}) = false
 function ismutable(::Type{T}) where {T}
     if parent_type(T) <: T
         return T.mutable


### PR DESCRIPTION
The default handling works for most numbers, but not for BigFloats because they are actually `mutable struct`, but don't act like a mutable array.

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/1400