### PR TITLE
Make axes(::Adjoint{<:Any,<:AbstractVector},1) == One():One()

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -163,10 +163,9 @@ Return a tuple of ranges where each range maps to each element along a dimension
     end
 end
 axes(A::PermutedDimsArray) = permute(axes(parent(A)), to_parent_dims(A))
-function axes(A::Union{Transpose,Adjoint})
-    p = parent(A)
-    return (axes(p, StaticInt(2)), axes(p, One()))
-end
+axes(A::Union{Transpose,Adjoint}) = _axes(A, parent(A))
+_axes(A::Union{Transpose,Adjoint}, p::AbstractVector) = (One():One(), axes(p, One()))
+_axes(A::Union{Transpose,Adjoint}, p::AbstractMatrix) = (axes(p, StaticInt(2)), axes(p, One()))
 axes(A::SubArray) = Base.axes(A)  # TODO implement ArrayInterface version
 axes(A::ReinterpretArray) = Base.axes(A)  # TODO implement ArrayInterface version
 axes(A::Base.ReshapedArray) = Base.axes(A)  # TODO implement ArrayInterface version

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -774,6 +774,8 @@ end
     @test @inferred(lzaxis[2]) === axis[2]
     @test @inferred(lzaxis[1:2:5]) === axis[1:2:5]
     @test @inferred(lzaxis[1:2]) === axis[1:2]
+    @test @inferred(ArrayInterface.axes(Array{Float64}(undef, 4)')) === (StaticInt(1):StaticInt(1),Base.OneTo(4))
+    @test @inferred(ArrayInterface.axes(Array{Float64}(undef, 4, 3)')) === (Base.OneTo(3),Base.OneTo(4))
 end
 
 include("ndindex.jl")


### PR DESCRIPTION
Before:
```julia
julia> using ArrayInterface

julia> x = rand(4);

julia> ArrayInterface.axes(x')
(Base.OneTo(1), Base.OneTo(4))
```
After:
```julia
julia> ArrayInterface.axes(x')
(1:1, Base.OneTo(4))

julia> typeof(ans)
Tuple{ArrayInterface.OptionallyStaticUnitRange{StaticInt{1}, StaticInt{1}}, Base.OneTo{Int64}}
```