### PR TITLE
Add `is_lazy_conjugate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ For example, if `A isa Base.Matrix`, `offsets(A) === (StaticInt(1), StaticInt(1)
 
 Is the function `f` whitelisted for `LoopVectorization.@avx`?
 
+## `is_lazy_conjugate(A)`
+
+Does the array `A` lazyily take complex conjugates of it's elements?
+
+
 # List of things to add
 
 - https://github.com/JuliaLang/julia/issues/22216

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -856,17 +856,17 @@ Examples
      1 + 1im
 
     julia> ArrayInterface.is_lazy_conjugate(a)
-    true
+    True()
 
     julia> b = a'
     1×2 adjoint(transpose(adjoint(::Vector{Complex{Int64}}))) with eltype Complex{Int64}:
      1+1im  1-1im
 
     julia> ArrayInterface.is_lazy_conjugate(b)
-    false
+    False()
 
 """
-is_lazy_conjugate(::T) where {T <: AbstractArray} = _is_lazy_conjugate(T, false)
+is_lazy_conjugate(::T) where {T <: AbstractArray} = _is_lazy_conjugate(T, False())
 
 function _is_lazy_conjugate(::Type{T}, isconj) where {T <: AbstractArray}
     Tp = parent_type(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -825,9 +825,6 @@ include("dimensions.jl")
     include("broadcast.jl")
 end
 
-using Test
-using ArrayInterface: is_lazy_conjugate
-
 @testset "lazy conj" begin
     a = rand(ComplexF64, 2)
     @test is_lazy_conjugate(a) == false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -827,14 +827,13 @@ end
 
 @testset "lazy conj" begin
     a = rand(ComplexF64, 2)
-    @test is_lazy_conjugate(a) == false
+    @test @inferred(is_lazy_conjugate(a)) == false
     b = a'
-    @test is_lazy_conjugate(b) == true
+    @test @inferred(is_lazy_conjugate(b)) == true
     c = transpose(b)
-    @test is_lazy_conjugate(c) == true
+    @test @inferred(is_lazy_conjugate(c)) == true
     d = c'
-    @test is_lazy_conjugate(d) == false
+    @test @inferred(is_lazy_conjugate(d)) == false
     e = permutedims(d)
-    @test is_lazy_conjugate(e) == false
-end 
-
+    @test @inferred(is_lazy_conjugate(e)) == false
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,8 @@ using Base: setindex
 using IfElse
 using ArrayInterface: StaticInt, True, False
 import ArrayInterface: has_sparsestruct, findstructralnz, fast_scalar_indexing, lu_instance,
-    device, contiguous_axis, contiguous_batch_size, stride_rank, dense_dims, static, NDIndex
+    device, contiguous_axis, contiguous_batch_size, stride_rank, dense_dims, static, NDIndex,
+    is_lazy_conjugate
 
 
 if VERSION ≥ v"1.6"
@@ -786,4 +787,19 @@ include("dimensions.jl")
     include("broadcast.jl")
 end
 
+using Test
+using ArrayInterface: is_lazy_conjugate
+
+@testset "lazy conj" begin
+    a = rand(ComplexF64, 2)
+    @test is_lazy_conjugate(a) == false
+    b = a'
+    @test is_lazy_conjugate(b) == true
+    c = transpose(b)
+    @test is_lazy_conjugate(c) == true
+    d = c'
+    @test is_lazy_conjugate(d) == false
+    e = permutedims(d)
+    @test is_lazy_conjugate(e) == false
+end 
 


### PR DESCRIPTION
This adds a function `is_lazy_conjugate` that can tell if a given array is supposed to lazyily take complex conjugates or not. It's meant to understand array wrappers, but if two nested wrappers have the exact same type in a row it will get confused. Not sure if there's a way around that other than whack-a-mole.

`Adjoint` is the only lazy-`conj` wrapper I know of, but the idea is that if anyone else has such types they can register here.