### PR TITLE
fix `contiguous_batch_size` for reshaped views

### DIFF
--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -269,6 +269,7 @@ function _contiguous_batch_size(::StaticInt{D}, ::R) where {D,R<:Tuple}
         return nothing
     end
 end
+_contiguous_batch_size(::StaticInt{-1}, ::R) where {R<:Tuple} = -One()
 
 contiguous_batch_size(::Type{Array{T,N}}) where {T,N} = Zero()
 contiguous_batch_size(::Type{BitArray{N}}) where {N} = Zero()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -398,6 +398,12 @@ using OffsetArrays
     @test @inferred(contiguous_batch_size(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:]))) === ArrayInterface.StaticInt(-1)
     @test @inferred(contiguous_batch_size(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:])')) === ArrayInterface.StaticInt(-1)
     @test @inferred(contiguous_batch_size(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])')) === ArrayInterface.StaticInt(0)
+    let u_base = randn(10, 10)
+        u_view = view(u_base, 3, :)
+        u_reshaped_view = reshape(u_view, 1, size(u_base, 2))
+        @test @inferred(contiguous_batch_size(u_view)) === ArrayInterface.StaticInt(-1)
+        @test @inferred(contiguous_batch_size(u_reshaped_view)) === ArrayInterface.StaticInt(-1)
+    end
 
     @test @inferred(stride_rank(@SArray(zeros(2,2,2)))) == (1, 2, 3)
     @test @inferred(stride_rank(A)) == (1,2,3)


### PR DESCRIPTION
This PR fixes the following bug in ArrayInterface `v3.1.15`:
```julia
julia> using ArrayInterface

julia> u_base = randn(10, 10);

julia> u_view = view(u_base, 3, :);

julia> ArrayInterface.contiguous_batch_size(u_view) # fine
static(-1)

julia> u_reshaped_view = reshape(u_view, 1, size(u_base, 2))
1×10 reshape(view(::Matrix{Float64}, 3, :), 1, 10) with eltype Float64:
 0.8578  1.29323  0.962883  0.365737  0.480809  0.424992  -0.578577  0.28492  -0.805345  0.4239

julia> ArrayInterface.contiguous_batch_size(u_reshaped_view)
ERROR: BoundsError: attempt to access Core.SimpleVector at index [-1]
Stacktrace:
 [1] getindex
   @ ./essentials.jl:589 [inlined]
 [2] _contiguous_batch_size(#unused#::Static.StaticInt{-1}, #unused#::Tuple{Static.StaticInt{1}, Static.StaticInt{2}})
   @ ArrayInterface ~/.julia/dev/ArrayInterface/src/stridelayout.jl:266
 [3] contiguous_batch_size
   @ ~/.julia/dev/ArrayInterface/src/stridelayout.jl:263 [inlined]
 [4] contiguous_batch_size(x::Base.ReshapedArray{Float64, 2, SubArray{Float64, 1, Matrix{Float64}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, true}, Tuple{}})
   @ ArrayInterface ~/.julia/dev/ArrayInterface/src/stridelayout.jl:262
 [5] top-level scope
   @ REPL[6]:1
```

The implemented behavior follows the docstring
> If `contiguous_axis(T) == -1`, it will return `StaticInt{-1}()`.

This bug occurred in one of my applications of `@turbo` from LoopVectorization.jl (CC @chriselrod).