### PR TITLE
Layouts - v2

### DIFF
--- a/src/array_index.jl
+++ b/src/array_index.jl
@@ -17,6 +17,20 @@ const VectorIndex = ArrayIndex{1}
 
 Base.ndims(::Type{<:ArrayIndex{N}}) where {N} = N
 
+Base.getindex(x::ArrayIndex{N}, i::Vararg{CanonicalInt,N}) where {N} = x[NDIndex(i)]
+
+struct LinkedIndex{N,I<:Tuple} <: ArrayIndex{N}
+    index::I
+
+    LinkedIndex(x::Tuple{I,Vararg{Any}}) where {I} = new{ndims(I),typeof(x)}(x)
+end
+
+link_index(f::Tuple) = Base.Fix2(link_index, f)
+link_index(x, f::Tuple) = LinkedIndex(_link_index(x, f))
+_link_index(x, f::Tuple{Any,Vararg{Any}}) = (first(f)(x), _link_index(x, tail(f))...)
+_link_index(x, f::Tuple{Any}) = (first(f)(x),)
+_link_index(x, f::Tuple{}) = ()
+
 struct BidiagonalIndex <: MatrixIndex
     count::Int
     isup::Bool
@@ -58,7 +72,7 @@ end
 struct BlockBandedMatrixIndex <: MatrixIndex
     count::Int
     refinds::Array{Int,1}
-    refcoords::Array{Int,1}# storing col or row inds at ref points
+    refcoords::Array{Int,1}  # storing col or row inds at ref points
     isrow::Bool
 end
 
@@ -188,16 +202,110 @@ struct StrideIndex{N,R,C,S,O,O1} <: ArrayIndex{N}
     offsets::O
     offset1::O1
 
+    function StrideIndex{N,R,C,S,O,O1}(s::S, o::O, o1::O1) where {N,R,C,S<:Tuple{Vararg{<:CanonicalInt,N}},O<:Tuple{Vararg{<:CanonicalInt,N}},O1}
+        new{N,R::NTuple{N,Int},C::Int,S,O,O1}(s, o, o1)
+    end
+    function StrideIndex{N,R,C,S,O,O1}(x) where {N,R,C,S<:Tuple{Vararg{<:CanonicalInt,N}},O<:Tuple{Vararg{<:CanonicalInt,N}},O1}
+        new{N,R::NTuple{N,Int},C::Int,S,O,O1}(strides(x), offsets(x), offset1(x))
+    end
     function StrideIndex{N,R,C}(s::S, o::O, o1::O1) where {N,R,C,S<:Tuple{Vararg{<:CanonicalInt,N}},O<:Tuple{Vararg{<:CanonicalInt,N}},O1}
-        return new{N,R::NTuple{N,Int},C::Int,S,O,O1}(s, o, o1)
+        new{N,R::NTuple{N,Int},C::Int,S,O,O1}(s, o, o1)
     end
     function StrideIndex{N,R,C}(a::A) where {N,R,C,A}
-        return StrideIndex{N,R,C}(strides(a),offsets(a),offset1(a))
+        StrideIndex{N,R,C}(strides(a),offsets(a),offset1(a))
     end
     function StrideIndex(a::A) where {A}
-        return StrideIndex{ndims(A),known(stride_rank(A)), known(contiguous_axis(A))}(a)
+        StrideIndex{ndims(A),known(stride_rank(A)), known(contiguous_axis(A))}(a)
     end
 end
+
+"""
+    LinearIndex
+
+Subtypes of `ArrayIndex` that transforms an index by by a common offset (`o1`).
+"""
+struct LinearIndex{O<:CanonicalInt} <: VectorIndex
+    offset1::O
+
+    LinearIndex{O}(x::O) where {O} = new{O}(x)
+    LinearIndex{O}(x::DenseArray) where {O} = LinearIndex{O}(static(0))
+end
+
+"""
+    PermutedIndex
+
+Subtypes of `ArrayIndex` that is responsible for permuting each index prior to accessing
+parent indices.
+"""
+struct PermutedIndex{N,perm} <: ArrayIndex{N}
+
+    PermutedIndex{N,perm}() where {N,perm} = new{N,perm}()
+    PermutedIndex{N,perm}(x::AbstractArray) where {N,perm} = new{N,perm}()
+end
+
+"""
+    SubIndex
+
+Subtypes of `ArrayIndex` that provides a multidimensional view of another `ArrayIndex`.
+"""
+struct SubIndex{N,I} <: ArrayIndex{N}
+    indices::I
+
+    SubIndex{N,I}(x::SubArray) where {N,I} = new{N,I}(x.indices)
+end
+
+"""
+    LinearSubIndex{S,I}
+
+Subtypes of `ArrayIndex` that provides a multidimensional view of another `ArrayIndex`.
+"""
+struct LinearSubIndex{S,I} <: VectorIndex
+    stride1::S
+    offset1::I
+
+    function LinearSubIndex{StaticInt{S},StaticInt{O}}() where {S,O}
+        new{StaticInt{S},StaticInt{O}}(StaticInt{S}(),StaticInt{O}())
+    end
+    LinearSubIndex{Int,Int}(x::SubArray) = new{S,I}(x.stride1, x.offset1)
+end
+
+"""
+    LinearNDIndex(offset1, offsets, size)
+
+A linear representation of a multidimensional index. Unlike `CartesianIndices`, indexing
+`LinearNDIndex` by an `StaticInt` can produce a static type (e.g., `NDIndex`).
+"""
+struct LinearNDIndex{N,O1,O<:Tuple{Vararg{CanonicalInt,N}},S<:Tuple{Vararg{CanonicalInt,N}}} <: VectorIndex
+    offset1::O1
+    offsets::O
+    size::S
+
+    function LinearNDIndex{N,O1,O,S}(x::AbstractArray) where {N,O1,O,S}
+        new{N,O1,O,S}(offset1(x), offsets(x), size(x))
+    end
+end
+
+struct NDLinearIndex{N,O1,O<:Tuple{Vararg{CanonicalInt,N}},S<:Tuple{Vararg{CanonicalInt,N}}} <: ArrayIndex{N}
+    offset1::O1
+    offsets::O
+    size::S
+
+    function NDLinearIndex{N,O1,O,S}(x::AbstractArray) where {N,O1,O,S}
+        new{N,O1,O,S}(offset1(x), offsets(x), size(x))
+    end
+end
+
+struct TransposedVectorIndex <: ArrayIndex{2}
+    TransposedVectorIndex() = new()
+end
+
+is_static(::Type{<:ArrayIndex}) = static(false)
+is_static(::Type{TransposedVectorIndex}) = static(true)
+is_static(::Type{LinearNDIndex{N,StaticInt,Tuple{Vararg{StaticInt,N}},Tuple{Vararg{StaticInt,N}}}}) where {N} = static(true)
+is_static(::Type{NDLinearIndex{N,StaticInt,Tuple{Vararg{StaticInt,N}},Tuple{Vararg{StaticInt,N}}}}) where {N} = static(true)
+is_static(::Type{StrideIndex{N,R,C,Tuple{Vararg{StaticInt,N}},Tuple{Vararg{StaticInt,N}},StaticInt}}) where {N,R,C} = static(true)
+is_static(::Type{LinearIndex{StaticInt}}) = static(true)
+is_static(::Type{LinearSubIndex{StaticInt,StaticInt}}) = static(true)
 
 Base.firstindex(i::Union{TridiagonalIndex,BandedBlockBandedMatrixIndex,BandedMatrixIndex,BidiagonalIndex,BlockBandedMatrixIndex}) = 1
 Base.lastindex(i::Union{TridiagonalIndex,BandedBlockBandedMatrixIndex,BandedMatrixIndex,BidiagonalIndex,BlockBandedMatrixIndex}) = i.count
@@ -268,7 +376,7 @@ function Base.getindex(ind::BandedBlockBandedMatrixIndex, i::Int)
     ind.reflocalinds[p][_i] + ind.refcoords[p] - 1
 end
 
-@inline function Base.getindex(x::StrideIndex{N}, i::CanonicalInt...) where {N}
+@inline function Base.getindex(x::StrideIndex{N}, i::AbstractCartesianIndex{N}) where {N}
     return _strides2int(x.offsets, x.strides, Tuple(i)) + x.offset1
 end
 @inline function _strides2int(o::Tuple, s::Tuple, i::Tuple)
@@ -276,3 +384,84 @@ end
 end
 _strides2int(::Tuple{}, ::Tuple{}, ::Tuple{}) = static(0)
 
+@inline function Base.getindex(x::PermutedIndex{N,perm}, i::AbstractCartesianIndex{N}) where {N,perm}
+    return NDIndex(permute(i, Val(perm)))
+end
+
+@inline function Base.getindex(x::SubIndex{N}, i::AbstractCartesianIndex{N}) where {N}
+    return NDIndex(_reindex(x.indices, Tuple(i)))
+end
+@generated function _reindex(subinds::S, inds::I) where {S,I}
+    inds_i = 1
+    subinds_i = 1
+    NS = known_length(S)
+    NI = known_length(I)
+    out = Expr(:tuple)
+    while (inds_i <= NI) && (subinds_i <= NS)
+        subinds_type = S.parameters[subinds_i]
+        if subinds_type <: Integer
+            push!(out.args, :(getfield(subinds, $subinds_i)))
+            subinds_i += 1
+        elseif subinds_type <: Slice
+            push!(out.args, :(getfield(inds, $inds_i)))
+            inds_i += 1
+            subinds_i += 1
+        else
+            T_i = eltype(subinds_type)
+            if T_i <: AbstractCartesianIndex
+                push!(out.args, :(Tuple(@inbounds(getfield(subinds, $subinds_i)[getfield(subinds, $inds_i)]))...))
+                inds_i += 1
+                subinds_i += 1
+            else
+                push!(out.args, :(Tuple(@inbounds(getfield(subinds, $subinds_i)[getfield(subinds, $inds_i)]))))
+                inds_i += 1
+                subinds_i += 1
+            end
+        end
+    end
+    return Expr(:block, Expr(:meta, :inline), :($out))
+end
+
+@inline function Base.getindex(x::NDLinearIndex{N}, i::AbstractCartesianIndex{N}) where {N}
+    inds = Tuple(arg)
+    o = offsets(x)
+    s = size(x)
+    return first(inds) + (offset1(x) - first(o)) + _subs2lin(first(s), tail(s), tail(o), tail(inds))
+end
+@inline function _subs2lin(str, s::Tuple{Any,Vararg}, o::Tuple{Any,Vararg}, i::Tuple{Any,Vararg})
+    return ((first(i) - first(o)) * str) + _subs2lin(str * first(s), tail(s), tail(o), tail(i))
+end
+_subs2lin(str, s::Tuple{Any}, o::Tuple{Any}, i::Tuple{Any}) = (first(i) - first(o)) * str
+# trailing inbounds can only be 1 or 1:1
+_subs2lin(str, ::Tuple{}, ::Tuple{}, ::Tuple{Any}) = static(0)
+
+@inline function Base.getindex(x::LinearNDIndex, i::CanonicalInt)
+    return NDIndex(_lin2subs(x.offsets, x.size, i - x.offset1))
+end
+@inline function _lin2subs(o::Tuple{Any,Vararg{Any}}, s::Tuple{Any,Vararg{Any}}, i::CanonicalInt)
+    len = first(s)
+    inext = div(i, len)
+    return (i - len * inext + first(o), _lin2subs(tail(o), tail(s), inext)...)
+end
+_lin2subs(o::Tuple{Any}, s::Tuple{Any}, i::CanonicalInt) = i + first(o)
+
+Base.getindex(x::LinearIndex, i::CanonicalInt) = x.offset1 + i
+
+Base.getindex(x::TransposedVectorIndex, i::AbstractCartesianIndex{2}) = last(Tuple(i))
+
+Base.getindex(x::LinearSubIndex, i::CanonicalInt) =  (x.strid1 * i) + x.offset1
+
+function Base.getindex(x::LinkedIndex{N}, i::AbstractCartesianIndex{N}) where {N}
+    return _get_linked_index(x.index, i)
+end
+Base.getindex(x::LinkedIndex{1}, i::CanonicalInt) = _get_linked_index(x.index, i)
+
+@generated function _get_linked_index(index::I, i) where {N,I<:Tuple{Vararg{Any,N}}}
+    out = :(@inbounds(getfield(index, 1)[i]))
+    if N > 1
+        for n in 2:N
+            out = :(@inbounds(getfield(index, $n)[$out]))
+        end
+    end
+    Expr(:block, Expr(:meta, :inline), out)
+end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -310,5 +310,5 @@ lazy_axes(x::LinearIndices) = axes(x)
 lazy_axes(x::CartesianIndices) = axes(x)
 @inline lazy_axes(x::MatAdjTrans) = reverse(lazy_axes(parent(x)))
 @inline lazy_axes(x::VecAdjTrans) = (LazyAxis{1}(x), first(lazy_axes(parent(x))))
-@inline lazy_axes(x::PermutedDimsArray) = permute(lazy_axes(parent(x)), to_parent_dims(A))
+@inline lazy_axes(x::PermutedDimsArray) = permute(lazy_axes(parent(x)), to_parent_dims(x))
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -471,7 +471,7 @@ function _generate_unsafe_get_layout_index!_body(N::Int)
             # the optimizer is not clever enough to split the union without it
             Dy === nothing && return dest
             (idx, state) = Dy
-            dest[idx] = m[Base.Cartesian.@nref($N, lyt, j)]
+            dest[idx] = m[lyt[NDIndex(Base.Cartesian.@ntuple($N, j))]]
             Dy = iterate(D, state)
         end
         return dest
@@ -495,7 +495,7 @@ function _generate_unsafe_get_index!_body(N::Int)
     end
 end
 
-function unsafe_get_index!(lyt::ArrayIndex, dest, src, I::Vararg{Any,N}) where {N}
+@generated function unsafe_get_index!(lyt::ArrayIndex, dest, src, I::Vararg{Any,N}) where {N}
     _generate_unsafe_get_layout_index!_body(N)
 end
 @generated function unsafe_get_index!(::Nothing, dest, src, I::Vararg{Any,N}) where {N}

--- a/src/layouts.jl
+++ b/src/layouts.jl
@@ -1,0 +1,242 @@
+
+function _stride_index_type(::Type{T}) where {T}
+    StrideIndex{
+        ndims(T),
+        known(stride_rank(T)),
+        known(contiguous_axis(T)),
+        _int_or_static_int(known_strides(T)),
+        _int_or_static_int(known_offsets(T)),
+        _int_or_static_int(known_offset1(T))
+    }
+end
+
+function _nd_linear_index_type(::Type{T}) where {T}
+    NDLinearIndex{
+        ndims(T),
+        _int_or_static_int(known_offset1(T)),
+        _int_or_static_int(known_offsets(T)),
+        _int_or_static_int(known_size(T))
+    }
+end
+function _linear_nd_index_type(::Type{T}) where {T}
+    LinearNDIndex{
+        ndims(T),
+        _int_or_static_int(known_offset1(T)),
+        _int_or_static_int(known_offsets(T)),
+        _int_or_static_int(known_size(T))
+    }
+end
+
+""" AccessStyle """
+abstract type AccessStyle end
+
+struct LinearAccess <: AccessStyle end
+
+struct CartesianAccess <: AccessStyle end
+
+struct UnorderedAccess <: AccessStyle end
+
+AccessStyle(x) = AccessStyle(typeof(x))
+AccessStyle(::Type{<:CanonicalInt}) = LinearAccess()
+AccessStyle(::Type{<:AbstractCartesianIndex}) = CartesianAccess()
+AccessStyle(::Type{<:AbstractArray{<:CanonicalInt}}) = LinearAccess()
+AccessStyle(::Type{<:AbstractArray{<:AbstractCartesianIndex}}) = CartesianAccess()
+AccessStyle(::Type{<:Tuple{I}}) where {I} = AccessStyle(I)
+AccessStyle(::Type{<:Tuple{I,Vararg{Any}}}) where {I} = CartesianAccess()
+
+"""
+    LayoutPlan(::Type{T}, a::AccessStyle)
+
+Provides a unique set of instructions for constructing a layout for any instance of the type
+`T` conditional on the `a`.
+
+* `index` : constructs the index transformation `index(::T)`. If `nothing` then there is no
+  transformation to an index passed between `T` and its referene data.
+* `plan` : adds additional index transformations to the layout of `T`.
+* `link` : if the `plan` field requires processing of any instance of `T` prior to execution
+  then `link` may contain the appropriate methods for doing so. For example, if `T` wraps
+  a parent type than `link` might be `parent`.
+"""
+struct LayoutPlan{I,P,L}
+    index::I
+    plan::P
+    link::L
+
+    LayoutPlan(index::I, plan::P, link::L) where {I,P,L} = new{I,P,L}(index, plan, link)
+end
+
+const WrapperPlan{P,L} = LayoutPlan{Nothing,P,L}
+# if the only thing that exists is a link function then no layout is actually produced
+const NoopPlan{L} = LayoutPlan{Nothing,Nothing,L}
+
+LayoutPlan(index, plan) = LayoutPlan(index, plan, nothing)
+
+# get rid of link when it doesn't go anywhere
+LayoutPlan(index, ::Nothing, link) = LayoutPlan(index, nothing, nothing)
+
+LayoutPlan(::Nothing, ::NoopPlan, link) = LayoutPlan(nothing, nothing, link)
+function LayoutPlan(::Nothing, plan::WrapperPlan, link)
+    LayoutPlan(nothing, plan.plan, _combine_links(link, plan.link))
+end
+_combine_links(link1, link2) = (link1, link2)
+_combine_links(link1, link2::Tuple) = (link1, link2...)
+_combine_links(::Nothing, link2) = link2
+_combine_links(::Nothing, link2::Tuple) = link2
+
+@generated function layout(a::A, ::S) where {A,S}
+    p = layout_plan(A, S())
+    if p === nothing
+        return nothing
+    else
+        Expr(:call, :LinkedIndex, Expr(:tuple, _layoutexpr(:a, p)...))
+    end
+end
+
+_layoutexpr(sym, p) = [:($p($sym))]
+_layoutexpr(sym, p::LayoutPlan{I,Nothing,Nothing}) where {I} = [:($(p.index)($sym))]
+function _layoutexpr(sym, p::LayoutPlan{I,P,Nothing}) where {I,P}
+    [_indexexpr(sym, p.index), _layoutexpr(sym, p.plan)...]
+end
+function _layoutexpr(sym, p::LayoutPlan{I,P,L}) where {I,P,L}
+    [_indexexpr(sym, p.index), _layoutexpr(_linkexpr(sym, p.link), p.plan)...]
+end
+_linkexpr(sym, link::Tuple{Any}) = :($(first(link))(sym))
+_linkexpr(sym, link::Tuple{Any,Vararg{Any}}) = _linkexpr(:($(first(link))(sym)), tail(link))
+_indexexpr(sym, index) = __indexexpr(is_static(index), sym, index)
+__indexexpr(::True, sym, index) = :($(index()))
+__indexexpr(::False, sym, index) = :($(index)($sym))
+
+""" layout_plan """
+layout_plan(::Any, ::AccessStyle) = nothing
+function layout_plan(::Type{A}, ::UnorderedAccess) where {A<:ReshapedArray}
+    p = layout_plan(parent_type(A), UnorderedAccess())
+    if p === nothing
+        return nothing
+    else
+        return LayoutPlan(nothing, p, parent)
+    end
+end
+function layout_plan(::Type{A}, ::LinearAccess) where {A<:ReshapedArray}
+    p = layout_plan(parent_type(A), LinearAccess())
+    if p === nothing
+        return nothing
+    else
+        return LayoutPlan(nothing, p, parent)
+    end
+end
+function layout_plan(::Type{A}, ::CartesianAccess) where {A<:ReshapedArray}
+    p = layout_plan(parent_type(A), LinearAccess())
+    if p === nothing
+        return nothing
+    else
+        return LayoutPlan(_nd_linear_index_type(A), p)
+    end
+end
+
+function layout_plan(::Type{A}, ::UnorderedAccess) where {A<:Union{PermutedDimsArray,Adjoint,Transpose}}
+    p = layout_plan(parent_type(A), UnorderedAccess())
+    if p === nothing
+        return nothing
+    else
+        return LayoutPlan(nothing, p, parent)
+    end
+end
+function layout_plan(::Type{A}, ::CartesianAccess) where {A<:Union{PermutedDimsArray,Adjoint,Transpose}}
+    combine_layouts(A, layout_plan(parent_type(A), CartesianAccess()))
+end
+function layout_plan(::Type{A}, ::LinearAccess) where {A<:Union{PermutedDimsArray,Adjoint,Transpose}}
+    LayoutPlan(
+        _linear_nd_index_type(A),
+        layout_plan(A, CartesianAccess())
+    )
+end
+
+function layout_plan(::Type{A}, ::UnorderedAccess) where {A<:SubArray}
+    I = _sub_indices_types(A) <: Tuple{Vararg{Slice}}
+    if I <: Tuple{Vararg{Slice}}
+        return LayoutPlan(nothing, layout_plan(parent_type(A), UnorderedAccess()), parent)
+    else
+        access = _view_access(I)
+        if LinearAccess() === access
+            return LayoutPlan(LinearIndices, layout_plan(parent_type(A), access), parent)
+        else
+            return LayoutPlan(CartesianIndices, layout_plan(parent_type(A), access), parent)
+        end
+    end
+end
+function layout_plan(::Type{A}, ::CartesianAccess) where {A<:SubArray}
+    combine_layouts(A, layout_plan(parent_type(A), CartesianAccess()))
+end
+function layout_plan(::Type{A}, ::LinearAccess) where {A<:SubArray}
+    access = _view_access(_sub_indices_types(A))
+    if LinearAccess() === access
+        return combine_layouts(A, layout_plan(parent_type(A), access))
+    else
+        return LayoutPlan(_linear_nd_index_type(A), combine_layouts(A, layout_plan(parent_type(A), access)))
+    end
+end
+_view_access(::Type{Tuple{}}) = LinearAccess()
+_view_access(::Type{I}) where {I<:Tuple{Real, Vararg{Any}}} = _view_access(Base.tuple_type_tail(I))
+_view_access(::Type{I}) where {I<:Tuple{Slice, Slice, Vararg{Any}}} = _view_access(Base.tuple_type_tail(I))
+_view_access(::Type{I}) where {I<:Tuple{Slice, AbstractUnitRange, Vararg{Real}}} = LinearAccess()
+_view_access(::Type{I}) where {I<:Tuple{Slice, Slice, Vararg{Real}}} = LinearAccess()
+_view_access(::Type{I}) where {I<:Tuple{AbstractRange, Vararg{Real}}} = LinearAccess()
+_view_access(::Type{I}) where {I<:Tuple{Vararg{Any}}} = CartesianAccess()
+_view_access(::Type{I}) where {I<:Tuple{AbstractArray,Vararg{Any}}} = CartesianAccess()
+
+layout_plan(::Type{A}, ::UnorderedAccess) where {A<:DenseArray} = indices
+layout_plan(::Type{A}, ::LinearAccess) where {A<:DenseArray} = LinearIndex{StaticInt{0}}
+layout_plan(::Type{A}, ::CartesianAccess) where {A<:DenseArray} = _stride_index_type(A)
+
+layout_plan(::Type{A}, ::IndexLinear) where {A<:AbstractRange} = LinearIndex{StaticInt{0}}
+layout_plan(::Type{A}, ::UnorderedAccess) where {A<:AbstractRange} = indices
+
+""" combine_layouts """
+combine_layouts(::Type{A}, ::Nothing) where {A} = nothing
+combine_layouts(::Type{A}, ::NoopPlan) where {A} = nothing
+function combine_layouts(::Type{A}, p::WrapperPlan) where {A}
+    _insert_previous_links(combine_layouts(A, p.plan), p.link)
+end
+_insert_previous_links(p, links) = p
+function _insert_previous_links(p::LayoutPlan, links)
+    LayoutPlan(p.index, p.plan, _combine_links(p.link, links))
+end
+function combine_layouts(::Type{A}, ::Type{I}) where {A<:VecAdjTrans,I<:ArrayIndex{1}}
+    LayoutPlan(TransposedVectorIndex, I, parent)
+end
+function combine_layouts(::Type{A}, ::Type{I}) where {A<:VecAdjTrans,I<:StrideIndex{1}}
+    _stride_index_type(A)
+end
+
+function combine_layouts(::Type{A}, ::Type{I}) where {A<:MatAdjTrans,I<:ArrayIndex{2}}
+    return LayoutPlan(PermutedIndex{2,(2,1)}, I, parent)
+end
+function combine_layouts(::Type{A}, ::Type{I}) where {A<:MatAdjTrans,I<:StrideIndex{2}}
+    _stride_index_type(A)
+end
+
+function combine_layouts(::Type{A}, ::Type{I}) where {N,perm,A<:PermutedDimsArray{<:Any,N,perm},I<:ArrayIndex{N}}
+    return LayoutPlan(PermutedIndex{N,perm}, I, parent)
+end
+function combine_layouts(::Type{A}, ::Type{I}) where {N,perm,A<:PermutedDimsArray{<:Any,N,perm},I<:StrideIndex{N}}
+    _stride_index_type(A)
+end
+
+combine_layouts(::Type{A}, ::Type{I}) where {A<:ReshapedArray,I<:ArrayIndex{1}} = I
+
+# TODO LinearIndex and LinearSubIndex may be static but SubArray doesn't account for this
+function combine_layouts(::Type{A}, ::Type{I}) where {A<:Base.FastSubArray,I<:ArrayIndex{1}}
+    LayoutPlan(LinearSubIndex{Int,Int}, I, parent)
+end
+function combine_layouts(::Type{A}, ::Type{I}) where {A<:Base.FastContiguousSubArray,I<:ArrayIndex{1}}
+    LayoutPlan(LinearIndex{Int}, I, parent)
+end
+
+function combine_layouts(::Type{A}, ::Type{I}) where {N,A<:SubArray{<:Any,N},I<:StrideIndex}
+    if defines_strides(A)
+        return _stride_index_type(A)
+    else
+        return LayoutPlan(SubIndex{N,_sub_indices_types(A)}, I, parent)
+    end
+end
+

--- a/src/ndindex.jl
+++ b/src/ndindex.jl
@@ -22,7 +22,7 @@ julia> i[1]
 
 ```
 """
-struct NDIndex{N,I<:Tuple{Vararg{Any,N}}} <: AbstractCartesianIndex{N}
+struct NDIndex{N,I<:Tuple{Vararg{CanonicalInt,N}}} <: AbstractCartesianIndex{N}
     index::I
 
     global _NDIndex(index::Tuple{Vararg{Any,N}}) where {N} = new{N,typeof(index)}(index)
@@ -39,6 +39,9 @@ struct NDIndex{N,I<:Tuple{Vararg{Any,N}}} <: AbstractCartesianIndex{N}
 
     NDIndex{0}(::Tuple{}) = new{0,Tuple{}}(())
     NDIndex{0}() = NDIndex{0}(())
+
+    NDIndex(i::Tuple{Vararg{CanonicalInt,N}}) where {N} = new{N,typeof(i)}(i)
+    NDIndex(i::Vararg{CanonicalInt,N}) where {N} = NDIndex(i)
 
     NDIndex(index::Tuple) = _NDIndex(_flatten(index...))
     NDIndex(index...) = _NDIndex(_flatten(index...))

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -22,6 +22,10 @@ function ArrayInterface.dimnames(::Type{T}, dim) where {L,T<:NamedDimsWrapper{L}
 end
 ArrayInterface.has_dimnames(::Type{T}) where {T<:NamedDimsWrapper} = true
 Base.parent(x::NamedDimsWrapper) = x.parent
+function ArrayInterface.layout_plan(::Type{A}, s::ArrayInterface.AccessStyle) where {A<:NamedDimsWrapper}
+    ArrayInterface.LayoutPlan(nothing, ArrayInterface.layout_plan(ArrayInterface.parent_type(A), s), parent)
+end
+
 
 @testset "dimension permutations" begin
     a = ones(2, 2, 2)

--- a/test/layouts.jl
+++ b/test/layouts.jl
@@ -1,0 +1,39 @@
+
+a = Array{Int}(undef, 5, 2, 5, 2); 
+a[:] .= 1:100;
+av = view(a, :, 1, :, :);
+aperm = PermutedDimsArray(a, (3,1,4,2));
+mv = view(aperm, :, 1, :, 1);
+mvp = mv';
+
+function layout_tests(x)
+    la = ArrayInterface.LinearAccess()
+    ca = ArrayInterface.CartesianAccess()
+
+    lytla = @inferred(ArrayInterface.layout(x, la))
+    lytca = @inferred(ArrayInterface.layout(x, ca))
+
+    m = ArrayInterface.refdata(x)
+
+    for i in eachindex(IndexLinear(), x)
+        @test x[i] === lytla[i] === m[lytla[i]]
+    end
+
+    for i in eachindex(IndexCartesian(), x)
+        @test x[i] === lytca[i] === m[lytca[i]]
+    end
+end
+
+layout_tests(a)
+layout_tests(av)
+layout_tests(aperm)
+layout_tests(mv)
+layout_tests(mvp)
+
+#=
+ArrayInterface.getindex(aperm, :, 1, :, 1)
+
+@btime ArrayInterface.StrideIndex(aperm)
+
+ArrayInterface.layout(av, la)
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -902,6 +902,7 @@ end
 include("ndindex.jl")
 include("indexing.jl")
 include("dimensions.jl")
+include("layouts.jl")
 
 @testset "broadcast" begin
     include("broadcast.jl")


### PR DESCRIPTION
Following feedback from #141 I've rewritten the approach to layouts.
The basic interface is as follows:

Given the array type `ArrayType` the `layout_plan` method may be written as follows.
```julia
function layout_plan(::Type{A}, s::AccessStyle) where {A<:ArrayType}
    # if `ArrayType` is the final index conversion
    ArrayTypeIndex

    # if `ArrayType` transforms whatever index it is given and passes it on to subsequent layers
    # `combine_layouts` takes whatever nested layers produces and provides an opportunity to combine it
    combine_layouts(A, layout_plan(parent_type(A), s))

    # if `s` is not a compatible access style propagate a new one and provide a converting index
    LayoutPlan(ConvertArrayTypeIndex, layout_plan(A, ProperAccess()))
end
```

<details>
<summary>Short note on implementation</summary>

`LayoutPlan` was inspired by `Base.Broadcast.Broadcasted` and a bit by `AbstractFFts.Plan`. Where `Broadcasted` flattens out and combines features and `AbstractFFts.Plan` uses type information to construct a new method based on an array type. I've used subtypes of `ArrayIndex` instead of traits so that we can use them as method calls and so they can hold dynamic information. This is a bit awkward when dealing with more complicated types such as `StrideIndex` but it's also a lot simpler than creating a method, trait, and index type for each type of index.

It's arguably easier to construct layouts with actual instances (e.g., `layout(x::X, s::AccessStyle) = combine_layouts(x, layout(parent(x), s))`), but I tried that and it completely kills performance. However, constructing a layout plan first with types also has the benefit of freeing us from worrying about constant propagation and potentially adding in other passes over the `LayoutPlan` before materializing it.
</details>


# Benchmarks

There's a lot of clean up that still needs to happen but initial benchmarks appear adequate.

```julia
a = Array{Int}(undef, 5, 2, 5, 2); 
a[:] .= 1:100;
av = view(a, :, 1, :, :);
aperm = PermutedDimsArray(a, (3,1,4,2));
mv = view(aperm, :, 1, :, 1);
mvp = mv';

julia> @btime ArrayInterface.getindex(a, :, 1, :, 1);
  492.411 ns (3 allocations: 368 bytes)

julia> @btime getindex(a, :, 1, :, 1);
  504.557 ns (10 allocations: 592 bytes)

julia> @btime ArrayInterface.getindex(aperm, :, 1, :, 1);
  490.788 ns (3 allocations: 240 bytes)

julia> @btime getindex(aperm, :, 1, :, 1);
  494.326 ns (13 allocations: 512 bytes)

julia> @btime ArrayInterface.getindex(av, :, 1, :);
  449.853 ns (3 allocations: 208 bytes)

julia> @btime getindex(av, :, 1, :);
  412.600 ns (9 allocations: 432 bytes)

julia> @btime ArrayInterface.getindex(mv, :, 1:2);
  221.106 ns (6 allocations: 384 bytes)

julia> @btime getindex(mv, :, 1:2);
  232.407 ns (3 allocations: 224 bytes)

julia> @btime ArrayInterface.getindex(mvp, :, 1:2);
  200.144 ns (6 allocations: 336 bytes)

julia> @btime getindex(mvp, :, 1:2);
  243.843 ns (3 allocations: 176 bytes)
```

Indexing `SubArray`s was consistently slower (as shown in these benchmarks), but I've yet to optimize indexing with layouts.
I'm actually surprised that performance is consistently doing better given the same exact array types and lack of any explicit specialization in constructing loops.

# For Review

* Biggest concern is whether the general interface makes sense. I'll certainly write documentation with more explicit examples than in this comment, but it's hard to know if if this makes sense in general. Months of coming back to this may have distorted my view.
* refdata - It might make more sense to have ManualMemory own this behavior. I don't care what the name is, maybe `preserve_buffer`
* reinterpret layout - this would require a unique buffer for reinterpreted values and probably a special index type. something else that could be in ManualMemory.jl?

Once we have layouts in place I think the only unique component of the array interface that still needs to be available here is constructing new instances of an array.
Assuming ManualMemory.jl becomes responsible for creating buffers, we could probably have a fairly simple method for wrapping buffers around newly constructed axes and attaching relevant metadata.

