### PR TITLE
clean up range code and documentation

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -393,7 +393,7 @@ Changing indexing based on a given argument from `args` should be done through,
 """
 @propagate_inbounds getindex(A, args...) = unsafe_get_index(A, to_indices(A, args))
 @propagate_inbounds function getindex(A; kwargs...)
-    return unsafe_get_index(A, to_indices(A, order_named_inds(dimnames(A), kwargs.data)))
+    return unsafe_get_index(A, to_indices(A, order_named_inds(dimnames(A), values(kwargs))))
 end
 @propagate_inbounds getindex(x::Tuple, i::Int) = getfield(x, i)
 @propagate_inbounds getindex(x::Tuple, ::StaticInt{i}) where {i} = getfield(x, i)
@@ -512,7 +512,7 @@ Store the given values at the given key or index within a collection.
     end
 end
 @propagate_inbounds function setindex!(A, val; kwargs...)
-    return unsafe_set_index!(A, val, to_indices(A, order_named_inds(dimnames(A), kwargs.data)))
+    return unsafe_set_index!(A, val, to_indices(A, order_named_inds(dimnames(A), values(kwargs))))
 end
 
 unsafe_set_index!(A, v, inds::Tuple) = _unsafe_set_index!(_is_element_index(inds), A, v, inds)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -734,7 +734,6 @@ end
         @test @inferred(ArrayInterface.strides(Ac2t)) === (StaticInt(1), 5)
         Ac2t_static = reinterpret(reshape, Tuple{Float64,Float64}, view(@MMatrix(rand(ComplexF64, 5, 7)), 2:4, 3:6));
         @test @inferred(ArrayInterface.strides(Ac2t_static)) === (StaticInt(1), StaticInt(5))
-
     end
 end
 


### PR DESCRIPTION
* Cleaned up messy code so that it's easier to read and more concise
* Previously test code in doc strings weren't in code blocks. Reimplemented them as comparable examples.
* Swapped `kwargs.data` to `values(kwargs)` in accordance to deprecation warning in Julia v1.7.