### PR TITLE
Add Equal() to indicate that offset1 equals first offset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.23"
+version = "3.1.24"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -944,6 +944,9 @@ function __init__()
         @inline axes(A::OffsetArrays.OffsetArray{T,N}, ::StaticInt{M}) where {T,M,N} = _axes(A, StaticInt{M}(), gt(StaticInt{M}(),StaticInt{N}()))
         @inline known_offset1(::Type{<:OffsetArrays.OffsetArray}) = 1
         @inline known_offset1(::Type{<:OffsetArrays.OffsetVector}) = nothing
+        function StrideIndex{N,R,C}(a::OffsetArrays.OffsetVector) where {N,R,C}
+            return StrideIndex{N,R,C}(strides(a),offsets(a),Equal())
+        end
     end
 end
 

--- a/src/array_index.jl
+++ b/src/array_index.jl
@@ -184,6 +184,19 @@ function BandedBlockBandedMatrixIndex(
 end
 
 """
+  Equal
+
+Equality indicator. Left generic to indicate possible other uses where it's easy to interpret.
+In case of `(s::StrideIndex).offset1 === Equal()`, this means that `offset1` is
+```julia
+s.offset[1]
+```
+
+Use of `StaticInt`s is preferred when possible for convenience. The purpose here is simply
+compressing runtime size information for when `StrideIndex` is passed as a non-inlined argument.
+"""
+struct Equal end
+"""
     StrideIndex(x)
 
 Subtype of `ArrayIndex` that transforms and index using stride layout information

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -74,7 +74,8 @@ known_offset1(x) = known_offset1(typeof(x))
 known_offset1(::Type{T}) where {T} = _known_offset1(has_parent(T), T)
 _known_offset1(::True, ::Type{T}) where {T} = known_offset1(parent_type(T))
 _known_offset1(::False, ::Type{T}) where {T} = 1
-known_offset(::Type{<:StrideIndex{N,R,C,S,O,O1}}) where {N,R,C,S,O,O1} = known(O1)
+known_offset1(::Type{<:StrideIndex{N,R,C,S,O,O1}}) where {N,R,C,S,O,O1} = known(O1)
+known_offset1(::Type{<:StrideIndex{N,R,C,S,O,Equal}}) where {N,R,C,S,O} = first(known(O))
 
 """
     offset1(x) -> Union{Int,StaticInt}
@@ -90,6 +91,7 @@ Returns the offset of the linear indices for `x`.
     end
 end
 offset1(x::StrideIndex) = getfield(x, :offset1)
+offset1(x::StrideIndex{N,R,C,S,O,Equal}) where {N,R,C,S,O} = getfield(getfield(x, :offsets), 1, false)
 
 """
     contiguous_axis(::Type{T}) -> StaticInt{N}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -697,6 +697,10 @@ end
         @test @inferred(ArrayInterface.known_offsets(ap_index)) === ArrayInterface.known_offsets(Ap)
         @test @inferred(ArrayInterface.known_offset1(ap_index)) === ArrayInterface.known_offset1(Ap)
         @test @inferred(ArrayInterface.known_strides(ap_index)) === ArrayInterface.known_strides(Ap)
+        
+        @test @inferred(ArrayInterface.known_offset1(o)) === nothing
+        @test @inferred(ArrayInterface.StrideIndex(o)).offset1 === ArrayInterface.Equal()
+        @test @inferred(ArrayInterface.offset1(o)) === @inferred(ArrayInterface.offset1(ArrayInterface.StrideIndex(o)))
     end
 
     if VERSION ≥ v"1.6.0-DEV.1581"


### PR DESCRIPTION
Save a value if we cross a function boundary with `OffsetVector`s.