### PR TITLE
`buffer` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.26"
+version = "3.1.27"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -42,6 +42,7 @@ ArrayInterface.aos_to_soa
 ArrayInterface.axes
 ArrayInterface.axes_types
 ArrayInterface.broadcast_axis
+ArrayInterface.buffer
 ArrayInterface.canonicalize
 ArrayInterface.deleteat
 ArrayInterface.dense_dims

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -82,6 +82,16 @@ _has_parent(::Type{T}, ::Type{T}) where {T} = False()
 _has_parent(::Type{T1}, ::Type{T2}) where {T1,T2} = True()
 
 """
+    buffer(x)
+
+Return the buffer data that `x` points to. Unlike `parent(x::AbstractArray)`, `buffer(x)`
+may not return another array.type.
+"""
+buffer(x) = parent(x)
+buffer(x::SparseMatrixCSC) = getfield(x, :nzval)
+buffer(x::SparseVector) = getfield(x, :nzval)
+
+"""
     known_length(::Type{T}) -> Union{Int,Nothing}
 
 If `length` of an instance of type `T` is known at compile time, return it.
@@ -698,6 +708,9 @@ function __init__()
         can_setindex(::Type{<:StaticArrays.StaticArray}) = false
         ismutable(::Type{<:StaticArrays.MArray}) = true
         ismutable(::Type{<:StaticArrays.SizedArray}) = true
+
+        buffer(A::Union{StaticArrays.SArray,StaticArrays.MArray}) = getfield(A, :data)
+        parent_type(::Type{<:StaticArrays.SizedArray{<:Any,<:Any,<:Any,<:Any,P}}) where {P} = P
 
         function lu_instance(_A::StaticArrays.StaticMatrix{N,N}) where {N}
             A = StaticArrays.SArray(_A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,6 +228,13 @@ end
     @test parent_type(Diagonal{Int,Vector{Int}}) <: Vector{Int}
     @test parent_type(UpperTriangular{Int,Matrix{Int}}) <: Matrix{Int}
     @test parent_type(LowerTriangular{Int,Matrix{Int}}) <: Matrix{Int}
+    @test parent_type(SizedVector{1, Int, Vector{Int}}) <: Vector{Int}
+end
+
+@testset "buffer" begin
+    @test ArrayInterface.buffer(Sp) == [1, 2, 3]
+    @test ArrayInterface.buffer(sparsevec([1, 2, 0, 0, 3, 0])) == [1, 2, 3]
+    @test ArrayInterface.buffer(Diagonal([1,2,3])) == [1, 2, 3]
 end
 
 include("ranges.jl")


### PR DESCRIPTION
See https://github.com/JuliaSIMD/ManualMemory.jl/pull/10 for context
Also added `parent_type(::Type{<:StaticArrays.SizedArray})` and `buffer` for `SArray` and `MArray`.