### PR TITLE
Cleanup/fix range and dimension related traits/methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.27"
+version = "3.1.28"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -14,9 +14,6 @@ using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretAr
 
 
 ## utilites for internal use only ##
-_int_or_static_int(::Nothing) = Int
-_int_or_static_int(x::Int) = StaticInt{x}
-
 @static if VERSION >= v"1.7.0-DEV.421"
     using Base: @aggressive_constprop
 else

--- a/src/array_index.jl
+++ b/src/array_index.jl
@@ -194,7 +194,7 @@ struct StrideIndex{N,R,C,S,O} <: ArrayIndex{N}
     offsets::O
 
     function StrideIndex{N,R,C}(s::S, o::O) where {N,R,C,S,O}
-        return new{N,R::NTuple{N,Int},C::Int,S,O}(s, o)
+        return new{N,R::NTuple{N,Int},C,S,O}(s, o)
     end
     function StrideIndex{N,R,C}(a::A) where {N,R,C,A}
         return StrideIndex{N,R,C}(strides(a), offsets(a))

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -1,5 +1,5 @@
 
-_static_range_type(::Nothing, ::Nothing) = OptionallyStaticUnitRange{Int,Int}
+_static_range_type(::Any, ::Any) = OptionallyStaticUnitRange{Int,Int}
 _static_range_type(start::Int, ::Nothing) = OptionallyStaticUnitRange{StaticInt{start},Int}
 function _static_range_type(start::Int, size::Int)
     OptionallyStaticUnitRange{StaticInt{start},StaticInt{(size - 1) + start}}

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -1,4 +1,10 @@
 
+_static_range_type(::Nothing, ::Nothing) = OptionallyStaticUnitRange{Int,Int}
+_static_range_type(start::Int, ::Nothing) = OptionallyStaticUnitRange{StaticInt{start},Int}
+function _static_range_type(start::Int, size::Int)
+    OptionallyStaticUnitRange{StaticInt{start},StaticInt{(size - 1) + start}}
+end
+
 """
     axes_types(::Type{T}) -> Type{Tuple{Vararg{AbstractUnitRange{Int}}}}
     axes_types(::Type{T}, dim) -> Type{AbstractUnitRange{Int}}
@@ -54,11 +60,9 @@ end
 @inline function axes_types(::Type{T}) where {N,P,I,T<:SubArray{<:Any,N,P,I}}
     return eachop_tuple(_sub_axis_type, to_parent_dims(T), T)
 end
+
 @inline function _sub_axis_type(::Type{A}, dim::StaticInt) where {T,N,P,I,A<:SubArray{T,N,P,I}}
-    return OptionallyStaticUnitRange{
-        _int_or_static_int(known_first(axes_types(P, dim))),
-        _int_or_static_int(known_length(_get_tuple(I, dim)))
-    }
+    _static_range_type(known_first(axes_types(P, dim)),known_length(_get_tuple(I, dim)))
 end
 
 function axes_types(::Type{R}) where {T,N,S,A,R<:ReinterpretArray{T,N,S,A}}

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,4 +1,7 @@
 
+_cartesian_index(i::Tuple{Vararg{Int}}) = CartesianIndex(i)
+_cartesian_index(::Any) = nothing
+
 """
     known_first(::Type{T}) -> Union{Int,Nothing}
 
@@ -22,6 +25,10 @@ function known_first(::Type{T}) where {T}
     end
 end
 known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
+function known_first(::Type{T}) where {N,R,T<:CartesianIndices{N,R}}
+    _cartesian_index(ntuple(i -> known_first(R.parameters[i]), Val(N)))
+end
+
 
 """
     known_last(::Type{T}) -> Union{Int,Nothing}
@@ -45,6 +52,9 @@ function known_last(::Type{T}) where {T}
     else
         return known_last(parent_type(T))
     end
+end
+function known_last(::Type{T}) where {N,R,T<:CartesianIndices{N,R}}
+    _cartesian_index(ntuple(i -> known_last(R.parameters[i]), Val(N)))
 end
 
 """

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -64,6 +64,9 @@ function _offsets(x::X, dim::StaticInt{D}) where {X,D}
         return static(start)
     end
 end
+# we can't generate an axis for `StrideIndex` so this is performed manually here
+@inline offsets(x::StrideIndex, dim::Int) = getfield(offsets(x), dim)
+@inline offsets(x::StrideIndex, ::StaticInt{dim}) where {dim} = getfield(offsets(x), dim)
 
 """
     known_offset1(::Type{T}) -> Union{Int,Nothing}
@@ -105,6 +108,8 @@ If no axis is contiguous, it returns a `StaticInt{-1}`.
 If unknown, it returns `nothing`.
 """
 contiguous_axis(x) = contiguous_axis(typeof(x))
+contiguous_axis(::Type{<:StrideIndex{N,R,C}}) where {N,R,C} = static(C)
+contiguous_axis(::Type{<:StrideIndex{N,R,Nothing}}) where {N,R} = nothing
 function contiguous_axis(::Type{T}) where {T}
     if parent_type(T) <: T
         return nothing
@@ -197,6 +202,8 @@ function rank_to_sortperm(R::Tuple{Vararg{StaticInt,N}}) where {N}
     return sp
 end
 
+stride_rank(::Type{<:StrideIndex{N,R}}) where {N,R} = static(R)
+stride_rank(::Type{<:StrideIndex{N,Nothing}}) where {N} = nothing
 stride_rank(x) = stride_rank(typeof(x))
 function stride_rank(::Type{T}) where {T}
     if parent_type(T) <: T

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -203,7 +203,6 @@ function rank_to_sortperm(R::Tuple{Vararg{StaticInt,N}}) where {N}
 end
 
 stride_rank(::Type{<:StrideIndex{N,R}}) where {N,R} = static(R)
-stride_rank(::Type{<:StrideIndex{N,Nothing}}) where {N} = nothing
 stride_rank(x) = stride_rank(typeof(x))
 function stride_rank(::Type{T}) where {T}
     if parent_type(T) <: T

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -109,7 +109,7 @@ If unknown, it returns `nothing`.
 """
 contiguous_axis(x) = contiguous_axis(typeof(x))
 contiguous_axis(::Type{<:StrideIndex{N,R,C}}) where {N,R,C} = static(C)
-contiguous_axis(::Type{<:StrideIndex{N,R,Nothing}}) where {N,R} = nothing
+contiguous_axis(::Type{<:StrideIndex{N,R,nothing}}) where {N,R} = nothing
 function contiguous_axis(::Type{T}) where {T}
     if parent_type(T) <: T
         return nothing

--- a/test/array_index.jl
+++ b/test/array_index.jl
@@ -1,0 +1,17 @@
+
+A = zeros(3, 4, 5);
+A[:] = 1:60
+Ap = @view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])';
+
+ap_index = ArrayInterface.StrideIndex(Ap)
+for x_i in axes(Ap, 1)
+    for y_i in axes(Ap, 2)
+        @test ap_index[x_i, y_i] == ap_index[x_i, y_i]
+    end
+end
+@test @inferred(ArrayInterface.known_offsets(ap_index)) === ArrayInterface.known_offsets(Ap)
+@test @inferred(ArrayInterface.known_offset1(ap_index)) === ArrayInterface.known_offset1(Ap)
+@test @inferred(ArrayInterface.known_strides(ap_index)) === ArrayInterface.known_strides(Ap)
+@test @inferred(ArrayInterface.contiguous_axis(ap_index)) == 1
+@test @inferred(ArrayInterface.stride_rank(ap_index)) == (1, 3)
+

--- a/test/array_index.jl
+++ b/test/array_index.jl
@@ -11,7 +11,10 @@ for x_i in axes(Ap, 1)
 end
 @test @inferred(ArrayInterface.known_offsets(ap_index)) === ArrayInterface.known_offsets(Ap)
 @test @inferred(ArrayInterface.known_offset1(ap_index)) === ArrayInterface.known_offset1(Ap)
+@test @inferred(ArrayInterface.offsets(ap_index, 1)) === ArrayInterface.offset1(Ap)
+@test @inferred(ArrayInterface.offsets(ap_index, static(1))) === ArrayInterface.offset1(Ap)
 @test @inferred(ArrayInterface.known_strides(ap_index)) === ArrayInterface.known_strides(Ap)
 @test @inferred(ArrayInterface.contiguous_axis(ap_index)) == 1
+@test @inferred(ArrayInterface.contiguous_axis(ArrayInterface.StrideIndex{2,(1,2),Nothing,NTuple{2,Int},NTuple{2,Int}})) == nothing
 @test @inferred(ArrayInterface.stride_rank(ap_index)) == (1, 3)
 

--- a/test/array_index.jl
+++ b/test/array_index.jl
@@ -15,6 +15,6 @@ end
 @test @inferred(ArrayInterface.offsets(ap_index, static(1))) === ArrayInterface.offset1(Ap)
 @test @inferred(ArrayInterface.known_strides(ap_index)) === ArrayInterface.known_strides(Ap)
 @test @inferred(ArrayInterface.contiguous_axis(ap_index)) == 1
-@test @inferred(ArrayInterface.contiguous_axis(ArrayInterface.StrideIndex{2,(1,2),Nothing,NTuple{2,Int},NTuple{2,Int}})) == nothing
+@test @inferred(ArrayInterface.contiguous_axis(ArrayInterface.StrideIndex{2,(1,2),nothing,NTuple{2,Int},NTuple{2,Int}})) == nothing
 @test @inferred(ArrayInterface.stride_rank(ap_index)) == (1, 3)
 

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -10,7 +10,6 @@ struct NamedDimsWrapper{L,T,N,P<:AbstractArray{T,N}} <: ArrayInterface.AbstractA
     NamedDimsWrapper{L}(p) where {L} = new{L,eltype(p),ndims(p),typeof(p)}(p)
 end
 ArrayInterface.parent_type(::Type{T}) where {P,T<:NamedDimsWrapper{<:Any,<:Any,<:Any,P}} = P
-ArrayInterface.has_dimnames(::Type{T}) where {T<:NamedDimsWrapper} = true
 ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = static(Val(L))
 function ArrayInterface.dimnames(::Type{T}, dim) where {L,T<:NamedDimsWrapper{L}}
     if ndims(T) < dim
@@ -19,7 +18,6 @@ function ArrayInterface.dimnames(::Type{T}, dim) where {L,T<:NamedDimsWrapper{L}
         return static(L[dim])
     end
 end
-ArrayInterface.has_dimnames(::Type{T}) where {T<:NamedDimsWrapper} = true
 Base.parent(x::NamedDimsWrapper) = x.parent
 
 @testset "dimension permutations" begin
@@ -90,18 +88,17 @@ end
     @test_throws ErrorException ArrayInterface.order_named_inds(n2, (x=30, y=20, z=40))
 end
 
-val_has_dimnames(x) = Val(ArrayInterface.has_dimnames(x))
 
 @testset "dimnames" begin
     d = (static(:x), static(:y))
     x = NamedDimsWrapper{d}(ones(2,2));
     y = NamedDimsWrapper{(:x,)}(ones(2));
     dnums = ntuple(+, length(d))
-    @test @inferred(val_has_dimnames(x)) === Val(true)
-    @test @inferred(ArrayInterface.has_dimnames(ones(2,2))) === false
-    @test @inferred(ArrayInterface.has_dimnames(Array{Int,2})) === false
-    @test @inferred(val_has_dimnames(typeof(x))) === Val(true)
-    @test @inferred(val_has_dimnames(typeof(view(x, :, 1, :)))) === Val(true)
+    @test @inferred(ArrayInterface.has_dimnames(x)) == true
+    @test @inferred(ArrayInterface.has_dimnames(ones(2,2))) == false
+    @test @inferred(ArrayInterface.has_dimnames(Array{Int,2})) == false
+    @test @inferred(ArrayInterface.has_dimnames(typeof(x))) == true
+    @test @inferred(ArrayInterface.has_dimnames(typeof(view(x, :, 1, :)))) == true
     @test @inferred(dimnames(x)) === d
     @test @inferred(dimnames(parent(x))) === (static(:_), static(:_))
     @test @inferred(dimnames(x')) === reverse(d)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -57,6 +57,15 @@
     @test isnothing(@inferred(ArrayInterface.known_last(typeof(1:4))))
     @test isone(@inferred(ArrayInterface.known_last(typeof(StaticInt(-1):StaticInt(2):StaticInt(1)))))
 
+    # CartesianIndices
+    CI = CartesianIndices((2, 2))
+    @test @inferred(ArrayInterface.known_first(typeof(CI))) == CartesianIndex(1, 1)
+    @test @inferred(ArrayInterface.known_last(typeof(CI))) == nothing
+
+    CI = CartesianIndices((static(1):static(2), static(1):static(2)))
+    @test @inferred(ArrayInterface.known_first(typeof(CI))) == CartesianIndex(1, 1)
+    @test @inferred(ArrayInterface.known_last(typeof(CI))) == CartesianIndex(2, 2)
+
     @test isnothing(@inferred(ArrayInterface.known_step(typeof(1:0.2:4))))
     @test isone(@inferred(ArrayInterface.known_step(1:4)))
     @test isone(@inferred(ArrayInterface.known_step(typeof(1:4))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -627,18 +627,6 @@ end
     o = OffsetArray(vec(A), 8);
     @test @inferred(ArrayInterface.offset1(o)) === 9
 
-    @testset "StrideIndex" begin
-        ap_index = ArrayInterface.StrideIndex(Ap)
-        for x_i in axes(Ap, 1)
-            for y_i in axes(Ap, 2)
-                @test ap_index[x_i, y_i] == ap_index[x_i, y_i]
-            end
-        end
-        @test @inferred(ArrayInterface.known_offsets(ap_index)) === ArrayInterface.known_offsets(Ap)
-        @test @inferred(ArrayInterface.known_offset1(ap_index)) === ArrayInterface.known_offset1(Ap)
-        @test @inferred(ArrayInterface.known_strides(ap_index)) === ArrayInterface.known_strides(Ap)
-    end
-
     if VERSION ≥ v"1.6.0-DEV.1581"
         colors = [(R = rand(), G = rand(), B = rand()) for i ∈ 1:100];
 
@@ -678,6 +666,10 @@ end
         Ac2t_static = reinterpret(reshape, Tuple{Float64,Float64}, view(@MMatrix(rand(ComplexF64, 5, 7)), 2:4, 3:6));
         @test @inferred(ArrayInterface.strides(Ac2t_static)) === (StaticInt(1), StaticInt(5))
     end
+end
+
+@testset "" begin
+    include("array_index.jl")
 end
 
 @testset "Reshaped views" begin


### PR DESCRIPTION
* `axes_types` was erroneously assuming that the the parent axis always had an offfset of 1
* `known_first` and `known_last` work for `CartesianIndices` now
* defined `contiguous_axis`, `stride_rank`, and `offset1` for `StrideIndex`
* `has_dimnames` returns `StaticBool` now. Not breaking because no downstream dependencies yet.