### PR TITLE
Uint static step

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.28"
+version = "3.1.29"
 
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -24,7 +24,7 @@ function known_first(::Type{T}) where {T}
         return known_first(parent_type(T))
     end
 end
-known_first(::Type{Base.OneTo{T}}) where {T} = one(T)
+known_first(::Type{Base.OneTo{T}}) where {T} = 1
 function known_first(::Type{T}) where {N,R,T<:CartesianIndices{N,R}}
     _cartesian_index(ntuple(i -> known_first(R.parameters[i]), Val(N)))
 end

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -70,7 +70,7 @@ function known_step(::Type{T}) where {T}
         return known_step(parent_type(T))
     end
 end
-known_step(::Type{<:AbstractUnitRange{T}}) where {T} = one(T)
+known_step(::Type{<:AbstractUnitRange}) = 1
 
 """
     OptionallyStaticUnitRange(start, stop) <: AbstractUnitRange{Int}

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -102,6 +102,7 @@
     @test_throws BoundsError getindex(ArrayInterface.OptionallyStaticUnitRange(StaticInt(1), 10), 11)
     @test_throws BoundsError getindex(ArrayInterface.OptionallyStaticStepRange(StaticInt(1), 2, 10), 11)
 
+    @test ArrayInterface.static_first(Base.OneTo(one(UInt))) === static(1)
     @test ArrayInterface.static_step(Base.OneTo(one(UInt))) === static(1)
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -92,5 +92,7 @@
     @test_throws BoundsError getindex(ArrayInterface.OptionallyStaticStepRange(StaticInt(1), 2, 10), 0)
     @test_throws BoundsError getindex(ArrayInterface.OptionallyStaticUnitRange(StaticInt(1), 10), 11)
     @test_throws BoundsError getindex(ArrayInterface.OptionallyStaticStepRange(StaticInt(1), 2, 10), 11)
+
+    @test ArrayInterface.static_step(Base.OneTo(one(UInt))) === static(1)
 end
 


### PR DESCRIPTION
The added test fails on current master.

This causes problems for `StrideArraysCore` which uses unsigned `Base.OneTo`s to avoid the check.