### PR TITLE
More dimension names documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -82,7 +82,7 @@ For example, all `Integers` passed to `to_dims` are converted to `Int` (unless `
 This is also useful for arrays that uniquely label dimensions, in which case `to_dims` serves as a safe point of hooking into existing methods with dimension arguments.
 `ArrayInterface` also defines native `Symbol` to `Int` and `StaticSymbol` to `StaticInt` mapping  for arrays defining [`ArrayInterface.dimnames`](@ref).
 
-Methods accepting dimension specific arguments should use some variation of the following pattern.
+Methods requiring dimension specific arguments should use some variation of the following pattern.
 
 ```julia
 f(x, dim) = f(x, ArrayInterface.to_dims(x, dim))
@@ -92,4 +92,19 @@ f(x, dim::StaticInt) = ...
 
 If `x`'s first dimension is named `:dim_1` then calling `f(x, :dim_1)` would result in `f(x, 1)`.
 If users knew they always wanted to call `f(x, 2)` then they could define `h(x) = f(x, static(2))`, ensuring `f` passes along that information while compiling.
+
+New types defining dimension names can do something similar to:
+```julia
+using Static
+using ArrayInterface
+
+struct NewType{dnames} end  # where dnames::Tuple{Vararg{Symbol}}
+
+ArrayInterface.dimnames(::Type{NewType{dnames}}) = static(dnames)
+```
+
+Dimension names should be appropriately propagated between nested arrays using `ArrayInterface.to_parent_dims`. 
+This allows types such as `SubArray` and `PermutedDimsArray` to work with named dimensions.
+Similarly, other methods that return information corresponding to dimensions (e.g., `ArrayInterfce.size`, `ArrayInterface.axes`) use `to_parent_dims` to appropriately propagate parent information.
+
 

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -10,14 +10,7 @@ struct NamedDimsWrapper{L,T,N,P<:AbstractArray{T,N}} <: ArrayInterface.AbstractA
     NamedDimsWrapper{L}(p) where {L} = new{L,eltype(p),ndims(p),typeof(p)}(p)
 end
 ArrayInterface.parent_type(::Type{T}) where {P,T<:NamedDimsWrapper{<:Any,<:Any,<:Any,P}} = P
-ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = static(Val(L))
-function ArrayInterface.dimnames(::Type{T}, dim) where {L,T<:NamedDimsWrapper{L}}
-    if ndims(T) < dim
-        return static(:_)
-    else
-        return static(L[dim])
-    end
-end
+ArrayInterface.dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}} = static(L)
 Base.parent(x::NamedDimsWrapper) = x.parent
 
 @testset "dimension permutations" begin


### PR DESCRIPTION
This provides a specific example of supporting `dimnames` and cleans up spaghetti code I originally wrote in the implementation of `dimnames`.