### PR TITLE
Fix stride_rank for equal-dim reinterpretarray

### DIFF
--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -239,7 +239,7 @@ function stride_rank(::Type{R}) where {T,N,S,A<:Array{S},R<:Base.ReinterpretArra
 end
 if VERSION ≥ v"1.6.0-DEV.1581"
   @inline function stride_rank(::Type{A}) where {NB, NA, B <: AbstractArray{<:Any,NB},A<: Base.ReinterpretArray{<:Any, NA, <:Any, B, true}}
-    _stride_rank_reinterpret(stride_rank(B), gt(StaticInt{NB}(), StaticInt{NA}()))
+    NA == NB ? stride_rank(B) : _stride_rank_reinterpret(stride_rank(B), gt(StaticInt{NB}(), StaticInt{NA}()))
   end
   @inline _stride_rank_reinterpret(sr, ::False) = (One(), map(Base.Fix2(+,One()),sr)...)
   @inline _stride_rank_reinterpret(sr::Tuple{One,Vararg}, ::True) = map(Base.Fix2(-,One()), tail(sr))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -364,6 +364,13 @@ ArrayInterface.parent_type(::Type{DenseWrapper{T,N,P}}) where {T,N,P} = P
     @test @inferred(stride_rank(DummyZeros(3,4)')) === nothing
     @test @inferred(stride_rank(PermutedDimsArray(DummyZeros(3,4), (2, 1)))) === nothing
     @test @inferred(stride_rank(view(DummyZeros(3,4), 1, :))) === nothing
+    uA = reinterpret(reshape, UInt64, A)
+    @test @inferred(stride_rank(uA)) === stride_rank(A)
+    rA = reinterpret(reshape, SVector{3,Float64}, A)
+    @test @inferred(stride_rank(rA)) === (static(1), static(2))
+    cA = copy(rA)
+    rcA = reinterpret(reshape, Float64, cA)
+    @test @inferred(stride_rank(rcA)) === stride_rank(A)
 
     #=
     @btime ArrayInterface.is_column_major($(PermutedDimsArray(A,(3,1,2))))


### PR DESCRIPTION
`reinterpret(reshape, T, A)` preserves the dimensionality (and size)
of `A` when `sizeof(T) == sizeof(eltype(A))`.