### PR TITLE
ArrayInterface.axes for ReshapedReinterpretArray

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -15,12 +15,10 @@ using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretAr
 
 const CanonicalInt = Union{Int,StaticInt}
 
-@static if VERSION ≥ v"1.6.0-DEV.1581"
-    _is_reshaped(::Type{ReinterpretArray{T,N,S,A,true}}) where {T,N,S,A} = true
-    _is_reshaped(::Type{ReinterpretArray{T,N,S,A,false}}) where {T,N,S,A} = false
-else
-    _is_reshaped(::Type{ReinterpretArray{T,N,S,A}}) where {T,N,S,A} = false
+@static if isdefined(Base, :ReshapedReinterpretArray)
+    _is_reshaped(::Type{<:Base.ReshapedReinterpretArray}) = true
 end
+_is_reshaped(::Type{<:ReinterpretArray}) = false
 
 Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -149,10 +149,10 @@ end
 
 @inline _axes(A::SubArray, dim::Integer) = Base.axes(A, Int(dim))  # TODO implement ArrayInterface version
 @inline function _axes(A::ReinterpretArray{T,N,S}, dim::Integer) where {T,N,S}
-  if _is_reshaped(typeof(A)) && (sizeof(S) > sizeof(T)) && dim == 1
-    return One():static(div(sizeof(S), sizeof(T)))
-  end
-  Base.axes(A, Int(dim))  # TODO implement ArrayInterface version
+    if _is_reshaped(typeof(A)) && (sizeof(S) > sizeof(T)) && dim == 1
+        return One():static(div(sizeof(S), sizeof(T)))
+    end
+    Base.axes(A, Int(dim))  # TODO implement ArrayInterface version
 end
 @inline _axes(A::Base.ReshapedArray, dim::Integer) = Base.axes(A, Int(dim))  # TODO implement ArrayInterface version
 
@@ -174,6 +174,13 @@ axes(A::Union{Transpose,Adjoint}) = _axes(A, parent(A))
 _axes(A::Union{Transpose,Adjoint}, p::AbstractVector) = (One():One(), axes(p, One()))
 _axes(A::Union{Transpose,Adjoint}, p::AbstractMatrix) = (axes(p, StaticInt(2)), axes(p, One()))
 axes(A::SubArray) = Base.axes(A)  # TODO implement ArrayInterface version
+if isdefined(Base, :ReshapedReinterpretArray)
+    function axes(A::Base.ReshapedReinterpretArray{T,N,S}) where {T,N,S}
+        sizeof(S) > sizeof(T) && return (_axes(A, 1), axes(parent(A))...)
+        sizeof(S) < sizeof(T) && return Base.tail(axes(parent(A)))
+        return axes(parent(A))
+    end
+end
 axes(A::ReinterpretArray) = Base.axes(A)  # TODO implement ArrayInterface version
 axes(A::Base.ReshapedArray) = Base.axes(A)  # TODO implement ArrayInterface version
 axes(A::CartesianIndices) = A.indices


### PR DESCRIPTION
This specializes `axes` for ReshapedReinterpretArray, and streamlines a
bit of the code surrounding this type.