### PR TITLE
Type stability fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.2.1"
+version = "3.2.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -445,13 +445,9 @@ Is strides(::T) defined? It is assumed that types returning `true` also return a
 pointer on `pointer(::T)`.
 """
 defines_strides(x) = defines_strides(typeof(x))
-function defines_strides(::Type{T}) where {T}
-    if parent_type(T) <: T
-        return false
-    else
-        return defines_strides(parent_type(T))
-    end
-end
+_defines_strides(::Type{T}, ::Type{T}) where {T} = false
+_defines_strides(::Type{P}, ::Type{T}) where {P,T} = defines_strides(P)
+defines_strides(::Type{T}) where {T} = _defines_strides(parent_type(T), T)
 defines_strides(::Type{<:StridedArray}) = true
 function defines_strides(::Type{<:SubArray{T,N,P,I}}) where {T,N,P,I}
     return stride_preserving_index(I) === True()


### PR DESCRIPTION
Tests still fail, but at least the inference tests no longer do:
```julia
to_indices: Test Failed at /Users/chriselrod/.julia/dev/ArrayInterface/test/indexing.jl:48
  Expression: #= /Users/chriselrod/.julia/dev/ArrayInterface/test/indexing.jl:48 =# @inferred(ArrayInterface.to_indices(a, inds)) == inds == (ArrayInterface.indices(a),)
   Evaluated: (Base.Slice(1:1:2),) == (Base.Slice(1:1:2),) == (Base.Slice(1:1:4),)
Stacktrace:
 [1] macro expansion
   @ ~/Documents/languages/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:479 [inlined]
 [2] macro expansion
   @ ~/.julia/dev/ArrayInterface/test/indexing.jl:48 [inlined]
 [3] macro expansion
   @ ~/Documents/languages/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:1375 [inlined]
 [4] top-level scope
   @ ~/.julia/dev/ArrayInterface/test/indexing.jl:33
to_indices: Test Failed at /Users/chriselrod/.julia/dev/ArrayInterface/test/indexing.jl:55
  Expression: #= /Users/chriselrod/.julia/dev/ArrayInterface/test/indexing.jl:55 =# @inferred(ArrayInterface.to_indices(a, (1, :))) == (1, Base.Slice(1:2))
   Evaluated: (1, Base.Slice(1:1:1)) == (1, Base.Slice(1:2))
Stacktrace:
 [1] macro expansion
   @ ~/Documents/languages/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:479 [inlined]
 [2] macro expansion
   @ ~/.julia/dev/ArrayInterface/test/indexing.jl:55 [inlined]
 [3] macro expansion
   @ ~/Documents/languages/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:1375 [inlined]
 [4] top-level scope
   @ ~/.julia/dev/ArrayInterface/test/indexing.jl:33
to_indices: Test Failed at /Users/chriselrod/.julia/dev/ArrayInterface/test/indexing.jl:57
  Expression: #= /Users/chriselrod/.julia/dev/ArrayInterface/test/indexing.jl:57 =# @inferred(ArrayInterface.to_indices(a, ([true, true], :))) == (Base.LogicalIndex(Bool[1, 1]), Base.Slice(1:2))
   Evaluated: ([1, 2], Base.Slice(1:1:1)) == ([1, 2], Base.Slice(1:2))
Stacktrace:
 [1] macro expansion
   @ ~/Documents/languages/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:479 [inlined]
 [2] macro expansion
   @ ~/.julia/dev/ArrayInterface/test/indexing.jl:57 [inlined]
 [3] macro expansion
   @ ~/Documents/languages/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:1375 [inlined]
 [4] top-level scope
   @ ~/.julia/dev/ArrayInterface/test/indexing.jl:33
Test Summary:     | Pass  Fail  Total  Time
to_indices        |   21     3     24  0.9s
  linear indexing |    4            4  0.0s
ERROR: LoadError: Some tests did not pass: 21 passed, 3 failed, 0 errored, 0 broken.
in expression starting at /Users/chriselrod/.julia/dev/ArrayInterface/test/indexing.jl:32
in expression starting at /Users/chriselrod/.julia/dev/ArrayInterface/test/runtests.jl:831
```