### PR TITLE
parent(::LazyAxis) returns the axis.

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -233,7 +233,7 @@ known_length(::Type{LazyAxis{N,P}}) where {N,P} = known_size(P, static(N))
 known_length(::Type{LazyAxis{:,P}}) where {P} = known_length(P)
 @inline function Base.length(x::LazyAxis{N})::Int where {N}
     if known_length(x) === nothing
-        return size(parent(x), static(N))
+        return size(getfield(x, :parent), static(N))
     else
         return known_length(x)
     end


### PR DESCRIPTION
@Tokazama lets get this merged, tag a new release, and then we can bump for the static update.

The reason tests started failing on Julia >= 1.7 is because `size` switched from using `unsafe_length` in <= 1.6 -- which gave the correct answer -- to using `length` in >= 1.7 -- which didn't.