### PR TITLE
Support static info on iterators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "4"
+version = "4.0.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -90,15 +90,13 @@ known_length(x) = known_length(typeof(x))
 known_length(::Type{<:NamedTuple{L}}) where {L} = length(L)
 known_length(::Type{T}) where {T<:Slice} = known_length(parent_type(T))
 known_length(::Type{<:Tuple{Vararg{Any,N}}}) where {N} = N
-known_length(::Type{T}) where {Itr,T<:Base.Generator{Itr}} = known_length(Itr)
 known_length(::Type{<:Number}) = 1
 known_length(::Type{<:AbstractCartesianIndex{N}}) where {N} = N
-function known_length(::Type{T}) where {T}
-    if parent_type(T) <: T
-        return missing
-    else
-        return prod(known_size(T))
-    end
+known_length(::Type{T}) where {T} = _maybe_known_length(Base.IteratorSize(T), T)
+_maybe_known_length(::Base.HasShape, ::Type{T}) where {T} = prod(known_size(T))
+_maybe_known_length(::Base.IteratorSize, ::Type) = missing
+function known_length(::Type{<:Iterators.Flatten{I}}) where {I}
+    known_length(I) * known_length(eltype(I))
 end
 
 """

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -3,6 +3,20 @@ function throw_dim_error(@nospecialize(x), @nospecialize(dim))
     throw(DimensionMismatch("$x does not have dimension corresponding to $dim"))
 end
 
+@propagate_inbounds function _promote_shape(a::Tuple{A,Vararg{Any}}, b::Tuple{B,Vararg{Any}}) where {A,B}
+    (_try_static(getfield(a, 1), getfield(b, 1)), _promote_shape(tail(a), tail(b))...)
+end
+_promote_shape(::Tuple{}, ::Tuple{}) = ()
+@propagate_inbounds function _promote_shape(::Tuple{}, b::Tuple{B}) where {B}
+    (_try_static(static(1), getfield(b, 1)),)
+end
+@propagate_inbounds function _promote_shape(a::Tuple{A}, ::Tuple{}) where {A}
+    (_try_static(static(1), getfield(a, 1)),)
+end
+@propagate_inbounds function Base.promote_shape(a::Tuple{Vararg{CanonicalInt}}, b::Tuple{Vararg{CanonicalInt}})
+    _promote_shape(a, b)
+end
+
 #julia> @btime ArrayInterface.is_increasing(ArrayInterface.nstatic(Val(10)))
 #  0.045 ns (0 allocations: 0 bytes)
 #ArrayInterface.True()

--- a/src/size.jl
+++ b/src/size.jl
@@ -47,7 +47,7 @@ size(x::Base.Generator) = size(getfield(x, :iter))
 size(x::Iterators.Reverse) = size(getfield(x, :itr))
 size(x::Iterators.Enumerate) = size(getfield(x, :itr))
 size(x::Iterators.Accumulate) = size(getfield(x, :itr))
-size(x::Base.Pairs) = size(getfield(x, :itr))
+size(x::Iterators.Pairs) = size(getfield(x, :itr))
 @inline function size(x::Iterators.ProductIterator)
     eachop(_sub_size, nstatic(Val(ndims(x))), getfield(x, :iterators))
 end
@@ -92,7 +92,7 @@ known_size(::Type{<:Base.Generator{I}}) where {I} = known_size(I)
 known_size(::Type{<:Iterators.Reverse{I}}) where {I} = known_size(I)
 known_size(::Type{<:Iterators.Enumerate{I}}) where {I} = known_size(I)
 known_size(::Type{<:Iterators.Accumulate{<:Any,I}}) where {I} = known_size(I)
-known_size(::Type{<:Base.Pairs{<:Any,<:Any,I}}) where {I} = known_size(I)
+known_size(::Type{<:Iterators.Pairs{<:Any,<:Any,I}}) where {I} = known_size(I)
 function known_size(::Type{<:Iterators.ProductIterator{I}}) where {I}
     eachop(_known_size, nstatic(Val(ndims(T))), I)
 end

--- a/src/size.jl
+++ b/src/size.jl
@@ -93,8 +93,8 @@ known_size(::Type{<:Iterators.Reverse{I}}) where {I} = known_size(I)
 known_size(::Type{<:Iterators.Enumerate{I}}) where {I} = known_size(I)
 known_size(::Type{<:Iterators.Accumulate{<:Any,I}}) where {I} = known_size(I)
 known_size(::Type{<:Iterators.Pairs{<:Any,<:Any,I}}) where {I} = known_size(I)
-function known_size(::Type{<:Iterators.ProductIterator{I}}) where {I}
-    eachop(_known_size, nstatic(Val(ndims(T))), I)
+function known_size(::Type{<:Iterators.ProductIterator{T}}) where {T}
+    eachop(_known_size, nstatic(Val(known_length(T))), T)
 end
 
 

--- a/src/size.jl
+++ b/src/size.jl
@@ -16,7 +16,10 @@ julia> ArrayInterface.size(A)
 (static(3), static(4))
 ```
 """
-@inline size(A) = map(static_length, axes(A))
+size(a::A) where {A} = _maybe_size(Base.IteratorSize(A), a)
+_maybe_size(::Base.HasShape{N}, a::A) where {N,A} = map(static_length, axes(a))
+_maybe_size(::Base.HasLength, a::A) where {A} = (static_length(a),)
+_maybe_size(::Base.IteratorSize, a) = throw(MethodError(size, (a,)))
 size(x::SubArray) = eachop(_sub_size, to_parent_dims(x), x.indices)
 _sub_size(x::Tuple, ::StaticInt{dim}) where {dim} = static_length(getfield(x, dim))
 @inline size(B::VecAdjTrans) = (One(), length(parent(B)))
@@ -40,6 +43,14 @@ function size(a::ReinterpretArray{T,N,S,A}) where {T,N,S,A}
 end
 size(A::ReshapedArray) = Base.size(A)
 size(A::AbstractRange) = (static_length(A),)
+size(x::Base.Generator) = size(getfield(x, :iter))
+size(x::Iterators.Reverse) = size(getfield(x, :itr))
+size(x::Iterators.Enumerate) = size(getfield(x, :itr))
+size(x::Iterators.Accumulate) = size(getfield(x, :itr))
+size(x::Base.Pairs) = size(getfield(x, :itr))
+@inline function size(x::Iterators.ProductIterator)
+    eachop(_sub_size, nstatic(Val(ndims(x))), getfield(x, :iterators))
+end
 
 size(a, dim) = size(a, to_dims(a, dim))
 size(a::Array, dim::Integer) = Base.arraysize(a, convert(Int, dim))
@@ -63,6 +74,7 @@ function size(A::SubArray, dim::Integer)
         return static_length(A.indices[pdim])
     end
 end
+size(x::Iterators.Zip) = Static.reduce_tup(promote_shape, map(size, getfield(x, :is)))
 
 """
     known_size(::Type{T}) -> Tuple
@@ -73,7 +85,36 @@ compile time. If a dimension does not have a known size along a dimension then `
 returned in its position.
 """
 known_size(x) = known_size(typeof(x))
-known_size(::Type{T}) where {T} = eachop(_known_size, nstatic(Val(ndims(T))), axes_types(T))
+function known_size(::Type{T}) where {T<:AbstractRange}
+    (_range_length(known_first(T), known_step(T), known_last(T)),)
+end
+known_size(::Type{<:Base.Generator{I}}) where {I} = known_size(I)
+known_size(::Type{<:Iterators.Reverse{I}}) where {I} = known_size(I)
+known_size(::Type{<:Iterators.Enumerate{I}}) where {I} = known_size(I)
+known_size(::Type{<:Iterators.Accumulate{<:Any,I}}) where {I} = known_size(I)
+known_size(::Type{<:Base.Pairs{<:Any,<:Any,I}}) where {I} = known_size(I)
+function known_size(::Type{<:Iterators.ProductIterator{I}}) where {I}
+    eachop(_known_size, nstatic(Val(ndims(T))), I)
+end
+
+
+# 1. `Zip` doesn't check that its collections are compatible (same size) at construction,
+#   but we assume as much b/c otherwise it will error while iterating. So we promote to the
+#   known size if matching a `Missing` and `Int` size.
+# 2. `promote_shape(::Tuple{Vararg{CanonicalInt}}, ::Tuple{Vararg{CanonicalInt}})` promotes
+#   trailing dimensions (which must be of size 1), to `static(1)`. We want to stick to
+#   `Missing` and `Int` types, so we do one last pass to ensure everything is dynamic
+@inline function known_size(::Type{<:Iterators.Zip{T}}) where {T}
+    dynamic(reduce_tup(_promote_shape, eachop(_unzip_size, nstatic(Val(known_length(T))), T)))
+end
+_unzip_size(::Type{T}, n::StaticInt{N}) where {T,N} = known_size(field_type(T, n))
+
+known_size(::Type{T}) where {T} = _maybe_known_size(Base.IteratorSize(T), T)
+function _maybe_known_size(::Base.HasShape{N}, ::Type{T}) where {N,T}
+    eachop(_known_size, nstatic(Val(N)), axes_types(T))
+end
+_maybe_known_size(::Base.HasLength, ::Type{T}) where {T} = (known_length(T),)
+_maybe_known_size(::Base.IteratorSize, ::Type) = missing
 _known_size(::Type{T}, dim::StaticInt) where {T} = known_length(field_type(T, dim))
 @inline known_size(x, dim) = known_size(typeof(x), dim)
 @inline known_size(::Type{T}, dim) where {T} = known_size(T, to_dims(T, dim))
@@ -84,3 +125,4 @@ _known_size(::Type{T}, dim::StaticInt) where {T} = known_length(field_type(T, di
         return known_size(T)[dim]
     end
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -496,6 +496,8 @@ end
     irev = Iterators.reverse(S)
     igen = Iterators.map(identity, S)
     iacc = Iterators.accumulate(+, S)
+    iprod = Iterators.product(axes(S)...)
+    iflat = Iterators.flatten(iprod)
     ienum = enumerate(S)
     ipairs = pairs(S)
     izip = zip(S,S)
@@ -514,7 +516,11 @@ end
     @test @inferred(ArrayInterface.size(A2)) === (4,3,5)
     @test @inferred(ArrayInterface.size(A2r)) === (2,3,5)
 
+
+    @test_throws MethodError ArrayInterface.size(Iterators.flatten(((x,y) for x in 0:1 for y in 'a':'c')))
     @test @inferred(ArrayInterface.size(irev)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(iprod)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(iflat)) === (static(72),)
     @test @inferred(ArrayInterface.size(igen)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(iacc)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(ienum)) === (StaticInt(2), StaticInt(3), StaticInt(4))
@@ -557,6 +563,8 @@ end
 
     @test @inferred(ArrayInterface.known_size(irev)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(igen)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(iprod)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(iflat)) === (72,)
     @test @inferred(ArrayInterface.known_size(iacc)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(ienum)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(izip)) === (2, 3, 4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -480,7 +480,7 @@ end
     A[:] = 1:60
     Ap = @view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])';
     S = @SArray zeros(2,3,4)
-    S_trailingdim = @SArray zeros(2,3,4,1)
+    A_trailingdim = zeros(2,3,4,1)
     Sp = @view(PermutedDimsArray(S,(3,1,2))[2:3,1:2,:]);
     M = @MArray zeros(2,3,4)
     Mp = @view(PermutedDimsArray(M,(3,1,2))[:,2,:])';
@@ -516,8 +516,6 @@ end
     @test @inferred(ArrayInterface.size(A2)) === (4,3,5)
     @test @inferred(ArrayInterface.size(A2r)) === (2,3,5)
 
-
-    @test_throws MethodError ArrayInterface.size(Iterators.flatten(((x,y) for x in 0:1 for y in 'a':'c')))
     @test @inferred(ArrayInterface.size(irev)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(iprod)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(iflat)) === (static(72),)
@@ -526,8 +524,8 @@ end
     @test @inferred(ArrayInterface.size(ienum)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(ipairs)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(izip)) === (StaticInt(2), StaticInt(3), StaticInt(4))
-    @test @inferred(ArrayInterface.size(zip(S, S_trailingdim))) === (StaticInt(2), StaticInt(3), StaticInt(4), static(1))
-    @test @inferred(ArrayInterface.size(zip(S_trailingdim, S))) === (StaticInt(2), StaticInt(3), StaticInt(4), static(1))
+    @test @inferred(ArrayInterface.size(zip(S, A_trailingdim))) === (StaticInt(2), StaticInt(3), StaticInt(4), static(1))
+    @test @inferred(ArrayInterface.size(zip(A_trailingdim, S))) === (StaticInt(2), StaticInt(3), StaticInt(4), static(1))
     @test @inferred(ArrayInterface.size(S)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(Sp)) === (2, 2, StaticInt(3))
     @test @inferred(ArrayInterface.size(Sp2)) === (2, StaticInt(3), StaticInt(2))
@@ -569,8 +567,9 @@ end
     @test @inferred(ArrayInterface.known_size(ienum)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(izip)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(ipairs)) === (2, 3, 4)
-    @test @inferred(ArrayInterface.known_size(zip(S, S_trailingdim))) === (2, 3, 4, 1)
-    @test @inferred(ArrayInterface.known_size(zip(S_trailingdim, S))) === (2, 3, 4, 1)
+    @test @inferred(ArrayInterface.known_size(zip(S, A_trailingdim))) === (2, 3, 4, 1)
+    @test @inferred(ArrayInterface.known_size(zip(A_trailingdim, S))) === (2, 3, 4, 1)
+    @test @inferred(ArrayInterface.known_length(Iterators.flatten(((x,y) for x in 0:1 for y in 'a':'c')))) === missing
 
     @test @inferred(ArrayInterface.known_size(S)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(Wrapper(S))) === (2, 3, 4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -479,8 +479,11 @@ end
     A = zeros(3, 4, 5);
     A[:] = 1:60
     Ap = @view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])';
-    S = @SArray zeros(2,3,4); Sp = @view(PermutedDimsArray(S,(3,1,2))[2:3,1:2,:]);
-    M = @MArray zeros(2,3,4); Mp = @view(PermutedDimsArray(M,(3,1,2))[:,2,:])';
+    S = @SArray zeros(2,3,4)
+    S_trailingdim = @SArray zeros(2,3,4,1)
+    Sp = @view(PermutedDimsArray(S,(3,1,2))[2:3,1:2,:]);
+    M = @MArray zeros(2,3,4)
+    Mp = @view(PermutedDimsArray(M,(3,1,2))[:,2,:])';
     Sp2 = @view(PermutedDimsArray(S,(3,2,1))[2:3,:,:]);
     Mp2 = @view(PermutedDimsArray(M,(3,1,2))[2:3,:,2])';
     D = @view(A[:,2:2:4,:]);
@@ -489,6 +492,14 @@ end
     Ar = reinterpret(Float32, A);
     A2 = zeros(4, 3, 5)
     A2r = reinterpret(ComplexF64, A2)
+
+    irev = Iterators.reverse(S)
+    igen = Iterators.map(identity, S)
+    iacc = Iterators.accumulate(+, S)
+    ienum = enumerate(S)
+    ipairs = pairs(S)
+    izip = zip(S,S)
+
 
     sv5 = @SVector(zeros(5)); v5 = Vector{Float64}(undef, 5);
     @test @inferred(ArrayInterface.size(sv5)) === (StaticInt(5),)
@@ -503,6 +514,14 @@ end
     @test @inferred(ArrayInterface.size(A2)) === (4,3,5)
     @test @inferred(ArrayInterface.size(A2r)) === (2,3,5)
 
+    @test @inferred(ArrayInterface.size(irev)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(igen)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(iacc)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(ienum)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(ipairs)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(izip)) === (StaticInt(2), StaticInt(3), StaticInt(4))
+    @test @inferred(ArrayInterface.size(zip(S, S_trailingdim))) === (StaticInt(2), StaticInt(3), StaticInt(4), static(1))
+    @test @inferred(ArrayInterface.size(zip(S_trailingdim, S))) === (StaticInt(2), StaticInt(3), StaticInt(4), static(1))
     @test @inferred(ArrayInterface.size(S)) === (StaticInt(2), StaticInt(3), StaticInt(4))
     @test @inferred(ArrayInterface.size(Sp)) === (2, 2, StaticInt(3))
     @test @inferred(ArrayInterface.size(Sp2)) === (2, StaticInt(3), StaticInt(2))
@@ -536,6 +555,15 @@ end
     @test @inferred(ArrayInterface.known_size(A2)) === (missing, missing, missing)
     @test @inferred(ArrayInterface.known_size(A2r)) === (missing, missing, missing)
 
+    @test @inferred(ArrayInterface.known_size(irev)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(igen)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(iacc)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(ienum)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(izip)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(ipairs)) === (2, 3, 4)
+    @test @inferred(ArrayInterface.known_size(zip(S, S_trailingdim))) === (2, 3, 4, 1)
+    @test @inferred(ArrayInterface.known_size(zip(S_trailingdim, S))) === (2, 3, 4, 1)
+
     @test @inferred(ArrayInterface.known_size(S)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(Wrapper(S))) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(Sp)) === (missing, missing, 3)
@@ -544,7 +572,6 @@ end
     @test @inferred(ArrayInterface.known_size(Sp2, StaticInt(1))) === missing
     @test @inferred(ArrayInterface.known_size(Sp2, StaticInt(2))) === 3
     @test @inferred(ArrayInterface.known_size(Sp2, StaticInt(3))) === 2
-
     @test @inferred(ArrayInterface.known_size(M)) === (2, 3, 4)
     @test @inferred(ArrayInterface.known_size(Mp)) === (3, 4)
     @test @inferred(ArrayInterface.known_size(Mp2)) === (2, missing)


### PR DESCRIPTION
* New support for types from `Base.Iterators`
* Check for `Base.IteratorSize` before assuming we can rely on axes when
  finding the size.
* Update internal calculation of range length to match base