### PR TITLE
ArrayInterface.Size instead of ArrayInterface.size

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -572,8 +572,8 @@ end
 
 abstract type AbstractArray2{T,N} <: AbstractArray{T,N} end
 
-Base.size(A::AbstractArray2) = map(Int, ArrayInterface.size(A))
-Base.size(A::AbstractArray2, dim) = Int(ArrayInterface.size(A, dim))
+Base.size(A::AbstractArray2) = Base.size(Size(A))
+Base.size(A::AbstractArray2, dim) = length(Size(A, dim))
 
 function Base.axes(A::AbstractArray2)
     !(parent_type(A) <: typeof(A)) && return ArrayInterface.axes(parent(A))
@@ -731,13 +731,13 @@ function __init__()
         @generated function axes_types(::Type{<:StaticArrays.StaticArray{S}}) where {S}
             return Tuple{[StaticArrays.SOneTo{s} for s in S.parameters]...}
         end
-        @generated function size(A::StaticArrays.StaticArray{S}) where {S}
+        @generated function ArrayInterface.Size(A::StaticArrays.StaticArray{S}) where {S}
             t = Expr(:tuple)
             Sp = S.parameters
             for n = 1:length(Sp)
                 push!(t.args, Expr(:call, Expr(:curly, :StaticInt, Sp[n])))
             end
-            return t
+            return :(ArrayInterface.Size($t))
         end
         @generated function strides(A::StaticArrays.StaticArray{S}) where {S}
             t = Expr(:tuple, Expr(:call, Expr(:curly, :StaticInt, 1)))

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -16,6 +16,7 @@ ArrayInterface.dimnames(x::NamedDimsWrapper) = getfield(x, :dimnames)
 function ArrayInterface.known_dimnames(::Type{T}) where {L,T<:NamedDimsWrapper{L}}
     ArrayInterface.Static.known(L)
 end
+ArrayInterface.Size(x::NamedDimsWrapper) = ArrayInterface.Size(parent(x))
 
 Base.parent(x::NamedDimsWrapper) = x.parent
 


### PR DESCRIPTION
This implements a formal type for extracting optionally static size info as I previously brought up [here](https://github.com/JuliaArrays/ArrayInterface.jl/issues/182#issuecomment-1005730557). If we do end up going this direction we can just leave a fall back to `ArrayInterface.size(x) = Size(x).size` so that we don't break any downstream code.

I think this is more beneficial than just creating a greater distinction between `Base.size` and `ArrayInterface.size`. It also allows passing `Size` as an unambiguous argument to methods like `similar` allocate a new array but currently dispatch on various combinations of integers and unit ranges for the `dims` argument.  I'm hoping this could be used in combination with `ArrayInterface.AbstractDevice` to give us a more complete story for array constructors.