### PR TITLE
Add issparsematrix

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -22,6 +22,7 @@ ArrayInterface.is_lazy_conjugate
 ArrayInterface.ismutable
 ArrayInterface.issingular
 ArrayInterface.isstructured
+ArrayInterface.issparsematrix
 ArrayInterface.is_splat_index
 ArrayInterface.known_dimnames
 ArrayInterface.known_first
@@ -85,4 +86,3 @@ ArrayInteraface.SOneTo
 ArrayInteraface.SUnitRange
 ArrayInterface.StrideIndex
 ```
-

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -400,6 +400,15 @@ function restructure(x::Array, y)
     reshape(convert(Array, y), Base.size(x)...)
 end
 
+"""
+    issparsematrix(A)
+
+Returns whether A is a structurally sparse matrix.
+"""
+issparsematrix(A::AbstractMatrix) = false
+issparsematrix(A::SparseMatrixCSC) = true
+
+
 abstract type AbstractDevice end
 abstract type AbstractCPU <: AbstractDevice end
 struct CPUPointer <: AbstractCPU end

--- a/src/cuarrays2.jl
+++ b/src/cuarrays2.jl
@@ -13,4 +13,4 @@ function restructure(x::CUDA.CuArray, y)
 end
 
 device(::Type{<:CUDA.CuArray}) = GPU()
-
+issparsematrix(A::CUDA.CUSPARSE.CuSparseMatrixCSC) = true


### PR DESCRIPTION
Looks like this is a missing verb in the sparse matrix vocabulary which is required for writing generic sparse functionality that also works on the GPU. Here's 3 PRs which currently only work on the CPU because of the missing verb:

- https://github.com/JuliaDiff/SparseDiffTools.jl/pull/179
- https://github.com/SciML/LinearSolve.jl/pull/104
- https://github.com/JuliaDiff/FiniteDiff.jl/pull/130

