### PR TITLE
axistype should create OneTo for better similar support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "5.0.1"
+version = "5.0.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -494,3 +494,7 @@ end
 function Base.similar(::Type{<:Array{T}}, axes::Tuple{OptionallyStaticUnitRange{StaticInt{1}},Vararg{Union{Base.OneTo,OptionallyStaticUnitRange{StaticInt{1}}}}}) where {T}
   Array{T}(undef, map(last, axes))
 end
+function Base.similar(::Type{<:Array{T}}, axes::Tuple{Base.OneTo,OptionallyStaticUnitRange{StaticInt{1}},Vararg{Union{Base.OneTo,OptionallyStaticUnitRange{StaticInt{1}}}}}) where {T}
+  Array{T}(undef, map(last, axes))
+end
+

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -187,8 +187,6 @@ end
     end
 end
 
-Base.Broadcast.axistype(r::OptionallyStaticUnitRange{StaticInt{1}}) = Base.OneTo(last(r))
-
 """
     SUnitRange(start::Int, stop::Int)
 
@@ -484,3 +482,15 @@ Returns valid indices for array `x` along each dimension specified in `dim`.
 _indices(x, dims::Tuple) = (indices(x, first(dims)), _indices(x, tail(dims))...)
 _indices(x, ::Tuple{}) = ()
 
+function Base.Broadcast.axistype(r::OptionallyStaticUnitRange{StaticInt{1}}, _)
+  Base.OneTo(last(r))
+end
+function Base.Broadcast.axistype(_, r::OptionallyStaticUnitRange{StaticInt{1}})
+  Base.OneTo(last(r))
+end
+function Base.Broadcast.axistype(r::OptionallyStaticUnitRange{StaticInt{1}}, ::OptionallyStaticUnitRange{StaticInt{1}})
+  Base.OneTo(last(r))
+end
+function Base.similar(::Type{<:Array{T}}, axes::Tuple{OptionallyStaticUnitRange{StaticInt{1}},Vararg{Union{Base.OneTo,OptionallyStaticUnitRange{StaticInt{1}}}}}) where {T}
+  Array{T}(undef, map(last, axes))
+end

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -187,6 +187,8 @@ end
     end
 end
 
+Base.Broadcast.axistype(r::OptionallyStaticUnitRange{StaticInt{1}}) = Base.OneTo(last(r))
+
 """
     SUnitRange(start::Int, stop::Int)
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -120,6 +120,9 @@
 
   @test @inferred(firstindex(128:static(-1):1)) == 1
 
-  @test similar(Matrix{Int}(undef, 2, 3), (static(1):4, Base.OneTo(5))) isa Matrix{Int}
+  @test identity.(static(1):5) isa Vector{Int}
+  @test (static(1):5) .+ (1:3)' isa Matrix{Int}
+  @test similar(Array{Int}, (static(1):(4), Base.OneTo(4))) isa Matrix{Int}
+  @test similar(Array{Int}, (static(1):(4),)) isa Vector{Int}
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -118,6 +118,8 @@
     @test @inferred(eachindex(static(-7):static(7))) === static(1):static(15)
     @test @inferred((static(-7):static(7))[first(eachindex(static(-7):static(7)))]) == -7
 
-    @test @inferred(firstindex(128:static(-1):1)) == 1
+  @test @inferred(firstindex(128:static(-1):1)) == 1
+
+  @test similar(Matrix{Int}(undef, 2, 3), (static(1):4, Base.OneTo(5))) isa Matrix{Int}
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -122,7 +122,8 @@
 
   @test identity.(static(1):5) isa Vector{Int}
   @test (static(1):5) .+ (1:3)' isa Matrix{Int}
-  @test similar(Array{Int}, (static(1):(4), Base.OneTo(4))) isa Matrix{Int}
   @test similar(Array{Int}, (static(1):(4),)) isa Vector{Int}
+  @test similar(Array{Int}, (static(1):(4), Base.OneTo(4))) isa Matrix{Int}
+  @test similar(Array{Int}, (Base.OneTo(4), static(1):(4))) isa Matrix{Int}
 end
 


### PR DESCRIPTION
When broadcasting with array types that returned `static(1):N` for axes, we'd get `OffsetArray`s instead of `Array`s. These should hopefully now generally be returning `Array`s instead:
```julia
  @test identity.(static(1):5) isa Vector{Int}
  @test (static(1):5) .+ (1:3)' isa Matrix{Int}
  @test similar(Array{Int}, (static(1):(4), Base.OneTo(4))) isa Matrix{Int}
  @test similar(Array{Int}, (static(1):(4),)) isa Vector{Int}
```
Under this PR, if the first `OptionatllyStaticUnitRange{StaticInt{1}}` occurs in index 3 or later of the tuple, it'll still result in an `OffsetArray`, but I figured getting these cases is enough.
It'd just require copy/pasting and adding more methods if we wanted to support deeper indices with the current approach.