### PR TITLE
Rename static_length to length and document

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -36,8 +36,26 @@ const MatAdjTrans{T,M<:AbstractMatrix{T}} = Union{Transpose{T,M},Adjoint{T,M}}
 const UpTri{T,M} = Union{UpperTriangular{T,M},UnitUpperTriangular{T,M}}
 const LoTri{T,M} = Union{LowerTriangular{T,M},UnitLowerTriangular{T,M}}
 
-@inline static_length(a::UnitRange{T}) where {T} = last(a) - first(a) + oneunit(T)
-@inline static_length(x) = Static.maybe_static(known_length, length, x)
+"""
+    length(A) -> Union{Int,StaticInt}
+
+Returns the length of `A`.  If the length is known at compile time, it is
+returned as `Static` number.  Otherwise, `ArrayInterface.length(A)` is identical
+to `Base.length(A)`.
+
+```julia
+julia> using StaticArrays, ArrayInterface
+
+julia> A = @SMatrix rand(3,4);
+
+julia> ArrayInterface.length(A)
+static(12)
+```
+"""
+@inline length(a::UnitRange{T}) where {T} = last(a) - first(a) + oneunit(T)
+@inline length(x) = Static.maybe_static(known_length, Base.length, x)
+const static_length = length  # for backward compatibility
+
 @inline static_first(x) = Static.maybe_static(known_first, first, x)
 @inline static_last(x) = Static.maybe_static(known_last, last, x)
 @inline static_step(x) = Static.maybe_static(known_step, step, x)

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -54,7 +54,9 @@ static(12)
 """
 @inline length(a::UnitRange{T}) where {T} = last(a) - first(a) + oneunit(T)
 @inline length(x) = Static.maybe_static(known_length, Base.length, x)
-const static_length = length  # for backward compatibility
+
+# Alias to to-be-depreciated internal function
+const static_length = length
 
 @inline static_first(x) = Static.maybe_static(known_first, first, x)
 @inline static_last(x) = Static.maybe_static(known_last, last, x)

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -30,7 +30,7 @@ broadcast_axis(x, y) = broadcast_axis(BroadcastAxis(x), x, y)
 # stagger default broadcasting in case y has something other than default
 broadcast_axis(::BroadcastAxisDefault, x, y) = _broadcast_axis(BroadcastAxis(y), x, y)
 function _broadcast_axis(::BroadcastAxisDefault, x, y)
-    return One():_combine_length(static_length(x), static_length(y))
+    return One():_combine_length(length(x), length(y))
 end
 _broadcast_axis(s::BroadcastAxis, x, y) = broadcast_axis(s, x, y)
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -243,7 +243,7 @@ indices calling [`to_axis`](@ref).
 @inline function to_axes(A, inds::Tuple)
     if ndims(A) === 1
         return (to_axis(axes(A, 1), first(inds)),)
-    elseif dynamic(length(inds)) === 1
+    elseif Base.length(inds) === 1
         return (to_axis(eachindex(IndexLinear(), A), first(inds)),)
     else
         return to_axes(A, axes(A), inds)
@@ -378,14 +378,14 @@ end
 _ints2range(x::Integer) = x:x
 _ints2range(x::AbstractRange) = x
 @inline function unsafe_get_collection(A::CartesianIndices{N}, inds) where {N}
-    if (dynamic(length(inds)) === 1 && N > 1) || stride_preserving_index(typeof(inds)) === False()
+    if (Base.length(inds) === 1 && N > 1) || stride_preserving_index(typeof(inds)) === False()
         return Base._getindex(IndexStyle(A), A, inds...)
     else
         return CartesianIndices(to_axes(A, _ints2range.(inds)))
     end
 end
 @inline function unsafe_get_collection(A::LinearIndices{N}, inds) where {N}
-    if dynamic(length(inds)) === 1 && isone(_ndims_index(typeof(inds), static(1)))
+    if Base.length(inds) === 1 && isone(_ndims_index(typeof(inds), static(1)))
         return @inbounds(eachindex(A)[first(inds)])
     elseif stride_preserving_index(typeof(inds)) === True()
         return LinearIndices(to_axes(A, _ints2range.(inds)))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -243,7 +243,7 @@ indices calling [`to_axis`](@ref).
 @inline function to_axes(A, inds::Tuple)
     if ndims(A) === 1
         return (to_axis(axes(A, 1), first(inds)),)
-    elseif length(inds) === 1
+    elseif dynamic(length(inds)) === 1
         return (to_axis(eachindex(IndexLinear(), A), first(inds)),)
     else
         return to_axes(A, axes(A), inds)
@@ -292,7 +292,7 @@ end
         return axis
     end
 end
-to_axis(S::IndexLinear, axis, inds) = StaticInt(1):static_length(inds)
+to_axis(S::IndexLinear, axis, inds) = StaticInt(1):length(inds)
 
 """
     ArrayInterface.getindex(A, args...)
@@ -378,14 +378,14 @@ end
 _ints2range(x::Integer) = x:x
 _ints2range(x::AbstractRange) = x
 @inline function unsafe_get_collection(A::CartesianIndices{N}, inds) where {N}
-    if (length(inds) === 1 && N > 1) || stride_preserving_index(typeof(inds)) === False()
+    if (dynamic(length(inds)) === 1 && N > 1) || stride_preserving_index(typeof(inds)) === False()
         return Base._getindex(IndexStyle(A), A, inds...)
     else
         return CartesianIndices(to_axes(A, _ints2range.(inds)))
     end
 end
 @inline function unsafe_get_collection(A::LinearIndices{N}, inds) where {N}
-    if length(inds) === 1 && isone(_ndims_index(typeof(inds), static(1)))
+    if dynamic(length(inds)) === 1 && isone(_ndims_index(typeof(inds), static(1)))
         return @inbounds(eachindex(A)[first(inds)])
     elseif stride_preserving_index(typeof(inds)) === True()
         return LinearIndices(to_axes(A, _ints2range.(inds)))

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -356,7 +356,7 @@ function Base.AbstractUnitRange{T}(r::OptionallyStaticUnitRange) where {T}
     end
 end
 
-Base.eachindex(r::OptionallyStaticRange) = One():static_length(r)
+Base.eachindex(r::OptionallyStaticRange) = One():length(r)
 @inline function Base.iterate(r::OptionallyStaticRange)
     isempty(r) && return nothing
     fi = Int(first(r));

--- a/src/size.jl
+++ b/src/size.jl
@@ -17,12 +17,12 @@ julia> ArrayInterface.size(A)
 ```
 """
 size(a::A) where {A} = _maybe_size(Base.IteratorSize(A), a)
-size(a::Base.Broadcast.Broadcasted) = map(static_length, axes(a))
+size(a::Base.Broadcast.Broadcasted) = map(length, axes(a))
 
-_maybe_size(::Base.HasShape{N}, a::A) where {N,A} = map(static_length, axes(a))
-_maybe_size(::Base.HasLength, a::A) where {A} = (static_length(a),)
+_maybe_size(::Base.HasShape{N}, a::A) where {N,A} = map(length, axes(a))
+_maybe_size(::Base.HasLength, a::A) where {A} = (length(a),)
 size(x::SubArray) = eachop(_sub_size, to_parent_dims(x), x.indices)
-_sub_size(x::Tuple, ::StaticInt{dim}) where {dim} = static_length(getfield(x, dim))
+_sub_size(x::Tuple, ::StaticInt{dim}) where {dim} = length(getfield(x, dim))
 @inline size(B::VecAdjTrans) = (One(), length(parent(B)))
 @inline size(B::MatAdjTrans) = permute(size(parent(B)), to_parent_dims(B))
 @inline function size(B::PermutedDimsArray{T,N,I1}) where {T,N,I1}
@@ -43,7 +43,7 @@ function size(a::ReinterpretArray{T,N,S,A}) where {T,N,S,A}
     end
 end
 size(A::ReshapedArray) = Base.size(A)
-size(A::AbstractRange) = (static_length(A),)
+size(A::AbstractRange) = (length(A),)
 size(x::Base.Generator) = size(getfield(x, :iter))
 size(x::Iterators.Reverse) = size(getfield(x, :itr))
 size(x::Iterators.Enumerate) = size(getfield(x, :itr))
@@ -72,7 +72,7 @@ function size(A::SubArray, dim::Integer)
     if pdim > ndims(parent_type(A))
         return size(parent(A), pdim)
     else
-        return static_length(A.indices[pdim])
+        return length(A.indices[pdim])
     end
 end
 size(x::Iterators.Zip) = Static.reduce_tup(promote_shape, map(size, getfield(x, :is)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -790,9 +790,9 @@ end
     v = @SVector rand(8);
     A = @MMatrix rand(7,6);
     T = SizedArray{Tuple{5,4,3}}(zeros(5,4,3));
-    @test @inferred(ArrayInterface.static_length(v)) === StaticInt(8)
-    @test @inferred(ArrayInterface.static_length(A)) === StaticInt(42)
-    @test @inferred(ArrayInterface.static_length(T)) === StaticInt(60)
+    @test @inferred(ArrayInterface.length(v)) === StaticInt(8)
+    @test @inferred(ArrayInterface.length(A)) === StaticInt(42)
+    @test @inferred(ArrayInterface.length(T)) === StaticInt(60)
 end
 
 @testset "indices" begin


### PR DESCRIPTION
I wasn't 100% sure how to best handle places where there was an `===` comparison to the result of `Base.length(x)`.  I ended up changing these to `dynamic(ArrrayInterface.length(x)) === ...`, but I'm not sure that is the preferred way.  Happy to make adjustments.

Also I'm not very familiar with Documenter and was getting the following warning:

```
┌ Warning: 3 docstrings not included in the manual:
│ 
│     ArrayInterface.SUnitRange
│     ArrayInterface.SOneTo
│     ArrayInterface.length :: Union{Tuple{UnitRange{T}}, Tuple{T}} where T
│ 
│ 
│ These are docstrings in the checked modules (configured with the modules keyword)
│ that are not included in @docs or @autodocs blocks.
```

Resolves #254