### PR TITLE
fix ndims_index(::CartesianIndices{0}) + ndims_index tests

### DIFF
--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -389,7 +389,6 @@ A scalar `setindex!` which is always allowed.
 """
 allowed_setindex!(x, v, i...) = Base.setindex!(x, v, i...)
 
-
 """
     ArrayIndex{N}
 
@@ -514,14 +513,14 @@ julia> ArrayInterface.known_step(typeof(1:4))
 """
 known_step(x) = known_step(typeof(x))
 known_step(::Type{T}) where {T} = parent_type(T) <: T ? nothing : known_step(parent_type(T))
-known_step(::Type{<:AbstractUnitRange}) = 1
+known_step(@nospecialize T::Type{<:AbstractUnitRange}) = 1
 
 """
     is_splat_index(::Type{T}) -> Bool
 Returns `static(true)` if `T` is a type that splats across multiple dimensions. 
 """
-is_splat_index(@nospecialize(x)) = is_splat_index(typeof(x))
 is_splat_index(T::Type) = false
+is_splat_index(@nospecialize(x)) = is_splat_index(typeof(x))
 
 """
     ndims_index(::Type{I}) -> Int
@@ -530,11 +529,13 @@ Returns the number of dimension that an instance of `I` maps to when indexing. F
 `CartesianIndex{3}` maps to 3 dimensions. If this method is not explicitly defined, then `1`
 is returned.
 """
-ndims_index(@nospecialize(i)) = ndims_index(typeof(i))
-ndims_index(::Type{I}) where {I} = 1
 ndims_index(::Type{<:Base.AbstractCartesianIndex{N}}) where {N} = N
-ndims_index(::Type{<:AbstractArray{T}}) where {T} = ndims_index(T)
-ndims_index(::Type{<:AbstractArray{Bool,N}}) where {N} = N
-ndims_index(::Type{<:Base.LogicalIndex{<:Any,<:AbstractArray{Bool,N}}}) where {N} = N
+# preserve CartesianIndices{0} as they consume a dimension.
+ndims_index(::Type{CartesianIndices{0,Tuple{}}}) = 1
+ndims_index(@nospecialize T::Type{<:AbstractArray{Bool}}) = ndims(T)
+ndims_index(@nospecialize T::Type{<:AbstractArray}) = ndims_index(eltype(T))
+ndims_index(@nospecialize T::Type{<:Base.LogicalIndex}) = ndims(fieldtype(T, :mask))
+ndims_index(T::DataType) = 1
+ndims_index(@nospecialize(i)) = ndims_index(typeof(i))
 
 end # module

--- a/lib/ArrayInterfaceCore/test/runtests.jl
+++ b/lib/ArrayInterfaceCore/test/runtests.jl
@@ -261,3 +261,10 @@ end
     @test isone(@inferred(ArrayInterfaceCore.known_step(typeof(view(1:4, 1:2)))))
 end
 
+@testset "ndims_index" begin
+    @test @inferred(ArrayInterfaceCore.ndims_index(CartesianIndices(()))) == 1
+    @test @inferred(ArrayInterfaceCore.ndims_index(trues(2, 2))) == 2
+    @test @inferred(ArrayInterfaceCore.ndims_index(CartesianIndex(2,2))) == 2
+    @test @inferred(ArrayInterfaceCore.ndims_index(1)) == 1
+end
+


### PR DESCRIPTION
When indexing empty `CartesianIndices` uniquely map to trailiing
dimensions that may be dropped. Therefore, we need to preserve them
as an indicator of which dimension to drop.