### PR TITLE
Use static indices for `deletat` and safer param access

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.6"
+version = "6.0.7"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -256,7 +256,7 @@ end
 @inline function unsafe_deleteat(src::Tuple, inds::AbstractVector)
     dst = Vector{eltype(src)}(undef, length(src) - length(inds))
     dst_index = firstindex(dst)
-    @inbounds for src_index in OneTo(length(src))
+    @inbounds for src_index in static(1):length(src)
         if !in(src_index, inds)
             dst[dst_index] = src[src_index]
             dst_index += one(dst_index)

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -17,7 +17,7 @@ end
     if dim > ndims(x)
         return SOneTo{1}
     else
-        return axes_types(x).parameters[dim]
+        return fieldtype(axes_types(x), dim)
     end
 end
 axes_types(x) = axes_types(typeof(x))

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -50,8 +50,8 @@ from_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _from_sub_dims(I
 @generated function _from_sub_dims(::Type{I}) where {I<:Tuple}
     out = Expr(:tuple)
     dim_i = 1
-    for i in 1:length(I.parameters)
-        p = I.parameters[i]
+    for i in 1:fieldcount(I)
+        p = fieldtype(I, i)
         if p <: CanonicalInt
             push!(out.args, :(StaticInt(0)))
         else
@@ -106,7 +106,8 @@ to_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _to_sub_dims(I)
 @generated function _to_sub_dims(::Type{I}) where {I<:Tuple}
     out = Expr(:tuple)
     n = 1
-    for p in I.parameters
+    for i in 1:fieldcount(I)
+        p = fieldtype(I, i)
         if !(p <: CanonicalInt)
             push!(out.args, :(StaticInt($n)))
         end


### PR DESCRIPTION
Since we created our own `ArrayInterface.length` we were calling
`OneTo(static_length)` indirectly. We might as well just use the known
indices so that if the compiler ever gets smart enough it can unroll
that. We also shouldn't be doing `T.parameters[i]` as much so this fixes
some of that.