### PR TITLE
Index set ranges

### DIFF
--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -2,12 +2,16 @@
 """
     OptionallyStaticUnitRange(start, stop, check_lower_bound=True(), check_upper_bound=True()) <: AbstractUnitRange{Int}
 
-Similar to `UnitRange` except each field may be an `Int` or `StaticInt`. An
-`OptionallyStaticUnitRange` is intended to be constructed internally from other valid
-indices. Therefore, users should not expect the same checks are used to ensure construction
-of a valid `OptionallyStaticUnitRange` as a `UnitRange`. `check_lower_bound` and
-`check_upper_bound` determine whether `start` and `stop` are bounds checked when
-`OptionallyStaticUnitRange` is used as an index.
+Similar to `UnitRange` except each field may be an `Int` or `StaticInt`. `check_lower_bound`
+and `check_upper_bound` determine whether `start` and `stop` are bounds checked when
+`OptionallyStaticUnitRange` is used as an index. This type is intended to be constructed
+internally from other valid indices. Therefore, users should not expect the same checks are
+used to ensure construction of a valid `OptionallyStaticUnitRange` as a `UnitRange`.
+
+!!! warning
+
+    Manually setting `check_lower_bound` and `check_upper_bound` to `False()` has similar
+    behavior as `@inbounds` and may result in incorrect results/crashes/corruption.
 """
 struct OptionallyStaticUnitRange{F<:CanonicalInt,L<:CanonicalInt,CLB<:Union{False,True},CUB<:Union{False,True}} <: AbstractUnitRange{Int}
     start::F
@@ -157,7 +161,7 @@ ArrayInterfaceCore.known_last(::Type{<:OptionallyStaticStepRange{<:Any,<:Any,Sta
         return known_first(r)
     end
 end
-function Base.step(r::OptionallyStaticStepRange)::Int
+@inline function Base.step(r::OptionallyStaticStepRange)::Int
     if known_step(r) === nothing
         return getfield(r, :step)
     else

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -43,7 +43,14 @@
     @test @inferred((static(1):static(10))[2:3]) === 2:3
     @test @inferred((1:static(10))[static(2):static(3)]) === 2:3
 
-    @test Base.checkindex(Bool, static(1):static(10), static(1):static(5))
+    @test !Base.checkindex(Bool, 1:5, ArrayInterface.OptionallyStaticUnitRange(1, 10, True(), True()))
+    @test !Base.checkindex(Bool, 1:5, ArrayInterface.OptionallyStaticUnitRange(1, 10, False(), True()))
+    @test Base.checkindex(Bool, 1:10, ArrayInterface.OptionallyStaticUnitRange(1, 5, False(), True()))
+    @test Base.checkindex(Bool, 1:10, ArrayInterface.OptionallyStaticUnitRange(1, 5, True(), False()))
+    @test Base.checkindex(Bool, 1:10, ArrayInterface.OptionallyStaticUnitRange(1, 5, True(), True()))
+    # these are actually out of bounds but we want to ensure that we can actually elide bounds checking
+    @test Base.checkindex(Bool, 1:5, ArrayInterface.OptionallyStaticUnitRange(1, 10, True(), False()))
+    @test Base.checkindex(Bool, 1:5, ArrayInterface.OptionallyStaticUnitRange(1, 10, False(), False()))
     @test -(static(1):static(10)) === static(-1):static(-1):static(-10)
 
     @test reverse(static(1):static(10)) === static(10):static(-1):static(1)
@@ -149,4 +156,3 @@ end
     @test ArrayInterface.indices((x',y'),StaticInt(1)) === Base.Slice(StaticInt(1):StaticInt(1))
     @test ArrayInterface.indices((x,y), StaticInt(2)) === Base.Slice(StaticInt(1):StaticInt(1))
 end
-

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -38,10 +38,10 @@
     @test AbstractUnitRange{UInt}(ArrayInterface.OptionallyStaticUnitRange(static(1), static(10))) isa Base.OneTo
     @test AbstractUnitRange{UInt}(ArrayInterface.OptionallyStaticUnitRange(static(2), static(10))) isa UnitRange
 
-    @test @inferred((static(1):static(10))[static(2):static(3)]) === static(2):static(3)
-    @test @inferred((static(1):static(10))[static(2):3]) === static(2):3
-    @test @inferred((static(1):static(10))[2:3]) === 2:3
-    @test @inferred((1:static(10))[static(2):static(3)]) === 2:3
+    @test @inferred((static(1):static(10))[static(2):static(3)]) == static(2):static(3)
+    @test @inferred((static(1):static(10))[static(2):3]) == static(2):3
+    @test @inferred((static(1):static(10))[2:3]) == 2:3
+    @test @inferred((1:static(10))[static(2):static(3)]) == 2:3
 
     @test !Base.checkindex(Bool, 1:5, ArrayInterface.OptionallyStaticUnitRange(1, 10, True(), True()))
     @test !Base.checkindex(Bool, 1:5, ArrayInterface.OptionallyStaticUnitRange(1, 10, False(), True()))


### PR DESCRIPTION
This is some ground work for supporting index types like those in [Dex](https://google-research.github.io/dex-lang/prelude.html#s-10).

I've added two fields to `OptionallyStaticUnitRange` and `OptionallyStaticStepRange` that allow manually eliding bounds checks for the first and last values in a range. These fields are not intended to be used directly by most users. Rather, the goal is to have functions that correspond to similar syntax as those in Dex (`i..`, `..i`, `i<..`, etc.), with a specific collection as a point of reference. I haven't yet decided what the actual method names should be to mirror this functionality. Perhaps something like, `all_indices(A, >(i))`? @AriMKatz, perhaps you have some ideas on this?

I've included benchmarks below just to demonstrate that this does provide the performance improvement you'd expect when skipping bounds checking. Providing formal methods for constructing these could also help avoid overuse and abuse of [`@inbounds`](https://github.com/JuliaLang/julia/issues/45342).

<details>

```julia

axis = Base.OneTo(20)
ur = 1:10
ur_checked = ArrayInterface.OptionallyStaticUnitRange(1, 10, False(), False())
ur_partially_checked = ArrayInterface.OptionallyStaticUnitRange(1, 10, False(), True())
ur_unchecked = ArrayInterface.OptionallyStaticUnitRange(1, 10, True(), True())

sr = 1:2:9
sr_checked = ArrayInterface.OptionallyStaticStepRange(1, 2, 9, False(), False())
sr_partially_checked = ArrayInterface.OptionallyStaticStepRange(1, 2, 9, False(), True())
sr_unchecked = ArrayInterface.OptionallyStaticStepRange(1, 2, 9, True(), True())

julia> @benchmark checkindex(Bool, $axis, $ur)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.832 ns … 17.912 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.093 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.158 ns ±  0.422 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

         █      ▁                               ▄▄            
  ▆▅▃▂▂▁▇█▇▂▂▁▁▅█▄▂▂▁▁▂▆▄▂▂▁▁▁▃▆▃▂▂▁▁▁▂▄▃▂▂▁▁▁▁▂██▆▂▂▂▁▁▂▃▅▃ ▃
  2.83 ns        Histogram: frequency by time        3.55 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark checkindex(Bool, $axis, $ur_checked)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  1.474 ns … 17.443 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.644 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.644 ns ±  0.278 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▁▁       ▅▃                                  ▁▁ ▂▇█▄   
  ▄▆▄▃▂██▅▄▆▇▅▄▆██▇▃▃▄▄▄▄▅▄▂▂▁▃▄▃▄▆▇▅▃▂▁▂▅▅▄▅▇█▅▃▂▂▂███████▇ ▄
  1.47 ns        Histogram: frequency by time        1.76 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark checkindex(Bool, $axis, $ur_partially_checked)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.545 ns … 17.384 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.723 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.833 ns ±  0.454 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

         █       ▃                               ▅            
  ▃▆▂▁▁▁▃██▂▁▂▁▁▆█▄▂▁▁▁▂▂▂▁▁▁▁▁▂▅▂▁▁▁▁▁▂▄▃▁▁▁▁▁▁▄██▂▁▁▁▁▁▁▂▂ ▂
  2.54 ns        Histogram: frequency by time         3.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark checkindex(Bool, $axis, $ur_unchecked)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.824 ns … 17.352 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.018 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.145 ns ±  0.387 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

         █▃                                    ▄              
  ▃▅▃▂▂▁▄██▄▂▂▂▄█▄▂▂▂▁▃▄▃▂▂▁▁▂▄▄▂▂▂▂▁▂▄▄▃▂▂▂▁▂▆██▃▂▂▂▁▂▂▃▃▂▂ ▃
  2.82 ns        Histogram: frequency by time        3.57 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark checkindex(Bool, $axis, $sr)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  3.193 ns … 26.974 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.614 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.589 ns ±  0.550 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▄ ▄▅  ▅▃  ▅▂  ▂▂   █▆   ▄▁    ▂▃▁  ▁                   ▁▃ ▂
  ██▄██▆▃██▄███▅▇██▁▆▆██▇▇▁██▅▃▁▁███▁▆█▇█▁▇█▄▁▁▆█▃▁▃▃▇▄▁▁▁██ █
  3.19 ns      Histogram: log(frequency) by time     4.74 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark checkindex(Bool, $axis, $sr_checked)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  1.477 ns … 15.597 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.731 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.741 ns ±  0.323 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

      ▃                 █                                     
  ▃▂▂▄█▅▃▂▅▃▂▂▅▅▃▂▂▆▄▃▂▃██▄▃▂▆▄▄▆▂▂▂▃▃▂▂▂▂▃▂▁▁▁▃▃▂▁▁▂▇▄▂▂▁▁▃ ▃
  1.48 ns        Histogram: frequency by time        2.13 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark checkindex(Bool, $axis, $sr_partially_checked)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.616 ns … 266.683 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.790 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.900 ns ±   2.690 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   █▁      ▁▆                                   ▇▇             
  ███▅▄▃▂▂▃███▇▄▂▂▂▃▄▄▃▃▂▂▂▂▃▄▃▃▃▂▂▁▁▃▅▅▃▃▂▂▂▁▁▅██▆▅▄▂▂▂▂▁▃▅▄ ▃
  2.62 ns         Histogram: frequency by time         3.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark checkindex(Bool, $axis, $sr_unchecked)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  2.904 ns … 17.856 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.206 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.225 ns ±  0.429 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   █      ▁▂                                   ▄▃         ▃   
  ██▆▃▂▂▁▂██▄▃▂▂▁▂▂▄▄▂▂▂▁▁▂▃▆▅▂▂▂▁▁▂▃▅▅▃▂▂▁▁▁▂▅██▄▂▂▂▁▁▂▃▆█▇ ▃
  2.9 ns         Histogram: frequency by time        3.55 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

 ```
</details>
