### PR TITLE
Clean up ReinterpretArray code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.9"
+version = "6.0.10"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -5,7 +5,7 @@ import ArrayInterfaceCore: allowed_getindex, allowed_setindex!, aos_to_soa, buff
     parent_type, fast_matrix_colors, findstructralnz, has_sparsestruct,
     issingular, isstructured, matrix_colors, restructure, lu_instance,
     safevec, zeromatrix, ColoringAlgorithm,
-    fast_scalar_indexing, parameterless_type, _is_reshaped, ndims_index, is_splat_index
+    fast_scalar_indexing, parameterless_type, ndims_index, is_splat_index
 
 # ArrayIndex subtypes and methods
 import ArrayInterfaceCore: ArrayIndex, MatrixIndex, VectorIndex, BidiagonalIndex, TridiagonalIndex

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -136,39 +136,37 @@ end
     end
 end
 
-if isdefined(Base, :ReshapedReinterpretArray)
-    function axes_types(::Type{A}) where {T,N,S,A<:Base.ReshapedReinterpretArray{T,N,S}}
-        if sizeof(S) > sizeof(T)
-            return merge_tuple_type(Tuple{SOneTo{div(sizeof(S), sizeof(T))}}, axes_types(parent_type(A)))
-        elseif sizeof(S) < sizeof(T)
-            P = parent_type(A)
-            return eachop_tuple(field_type, tail(nstatic(Val(ndims(P)))), axes_types(P))
-        else
-            return axes_types(parent_type(A))
-        end
+function axes_types(::Type{A}) where {T,N,S,A<:Base.ReshapedReinterpretArray{T,N,S}}
+    if sizeof(S) > sizeof(T)
+        return merge_tuple_type(Tuple{SOneTo{div(sizeof(S), sizeof(T))}}, axes_types(parent_type(A)))
+    elseif sizeof(S) < sizeof(T)
+        P = parent_type(A)
+        return eachop_tuple(field_type, tail(nstatic(Val(ndims(P)))), axes_types(P))
+    else
+        return axes_types(parent_type(A))
     end
-    @inline function axes(A::Base.ReshapedReinterpretArray{T,N,S}) where {T,N,S}
-        if sizeof(S) > sizeof(T)
-            return (SOneTo(div(sizeof(S), sizeof(T))), axes(parent(A))...)
-        elseif sizeof(S) < sizeof(T)
-            return tail(axes(parent(A)))
-        else
-            return axes(parent(A))
-        end
+end
+@inline function axes(A::Base.ReshapedReinterpretArray{T,N,S}) where {T,N,S}
+    if sizeof(S) > sizeof(T)
+        return (SOneTo(div(sizeof(S), sizeof(T))), axes(parent(A))...)
+    elseif sizeof(S) < sizeof(T)
+        return tail(axes(parent(A)))
+    else
+        return axes(parent(A))
     end
-    @inline function axes(A::Base.ReshapedReinterpretArray{T,N,S}, dim) where {T,N,S}
-        d = to_dims(A, dim)
-        if sizeof(S) > sizeof(T)
-            if d == 1
-                return SOneTo(div(sizeof(S), sizeof(T)))
-            else
-                return axes(parent(A), d - static(1))
-            end
-        elseif sizeof(S) < sizeof(T)
+end
+@inline function axes(A::Base.ReshapedReinterpretArray{T,N,S}, dim) where {T,N,S}
+    d = to_dims(A, dim)
+    if sizeof(S) > sizeof(T)
+        if d == 1
+            return SOneTo(div(sizeof(S), sizeof(T)))
+        else
             return axes(parent(A), d - static(1))
-        else
-            return axes(parent(A), d)
         end
+    elseif sizeof(S) < sizeof(T)
+        return axes(parent(A), d - static(1))
+    else
+        return axes(parent(A), d)
     end
 end
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -62,8 +62,8 @@ from_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _from_sub_dims(I
     out
 end
 from_parent_dims(::Type{<:PermutedDimsArray{T,N,<:Any,I}}) where {T,N,I} = static(Val(I))
-function from_parent_dims(::Type{R}) where {T,N,S,A,R<:ReinterpretArray{T,N,S,A}}
-    if !_is_reshaped(R) || sizeof(S) === sizeof(T)
+function from_parent_dims(::Type{<:ReinterpretArray{T,N,S,A,IsReshaped}}) where {T,N,S,A,IsReshaped}
+    if !IsReshaped || sizeof(S) === sizeof(T)
         return nstatic(Val(ndims(A)))
     elseif sizeof(S) > sizeof(T)
         return tail(nstatic(Val(ndims(A) + 1)))
@@ -115,9 +115,9 @@ to_parent_dims(::Type{<:SubArray{T,N,A,I}}) where {T,N,A,I} = _to_sub_dims(I)
     end
     out
 end
-function to_parent_dims(::Type{R}) where {T,N,S,A,R<:ReinterpretArray{T,N,S,A}}
+function to_parent_dims(::Type{<:ReinterpretArray{T,N,S,A,IsReshaped}}) where {T,N,S,A,IsReshaped}
     pdims = nstatic(Val(ndims(A)))
-    if !_is_reshaped(R) || sizeof(S) === sizeof(T)
+    if !IsReshaped || sizeof(S) === sizeof(T)
         return pdims
     elseif sizeof(S) > sizeof(T)
         return (Zero(), pdims...,)

--- a/src/size.jl
+++ b/src/size.jl
@@ -28,9 +28,9 @@ _sub_size(x::Tuple, ::StaticInt{dim}) where {dim} = length(getfield(x, dim))
 @inline function size(B::PermutedDimsArray{T,N,I1}) where {T,N,I1}
     permute(size(parent(B)), static(I1))
 end
-function size(a::ReinterpretArray{T,N,S,A}) where {T,N,S,A}
+function size(a::ReinterpretArray{T,N,S,A,IsReshaped}) where {T,N,S,A,IsReshaped}
     psize = size(parent(a))
-    if _is_reshaped(typeof(a))
+    if IsReshaped
         if sizeof(S) === sizeof(T)
             return psize
         elseif sizeof(S) > sizeof(T)

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -36,23 +36,21 @@
     @test_throws DimensionMismatch ArrayInterface.from_parent_dims(typeof(vadj), 0)
     @test_throws DimensionMismatch ArrayInterface.from_parent_dims(typeof(vadj), static(0))
 
-    if VERSION ≥ v"1.6.0-DEV.1581"
-        colormat = reinterpret(reshape, Float64, [(R=rand(), G=rand(), B=rand()) for i ∈ 1:100])
-        @test @inferred(ArrayInterface.from_parent_dims(typeof(colormat))) === (static(2),)
-        @test @inferred(ArrayInterface.to_parent_dims(typeof(colormat))) === (static(0), static(1),)
+    colormat = reinterpret(reshape, Float64, [(R=rand(), G=rand(), B=rand()) for i ∈ 1:100])
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(colormat))) === (static(2),)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(colormat))) === (static(0), static(1),)
 
-        Rr = reinterpret(reshape, Int32, ones(4))
-        @test @inferred(ArrayInterface.from_parent_dims(typeof(Rr))) === (static(2),)
-        @test @inferred(ArrayInterface.to_parent_dims(typeof(Rr))) === (static(0), static(1),)
+    Rr = reinterpret(reshape, Int32, ones(4))
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(Rr))) === (static(2),)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(Rr))) === (static(0), static(1),)
 
-        Rr = reinterpret(reshape, Int64, ones(4))
-        @test @inferred(ArrayInterface.from_parent_dims(typeof(Rr))) === (static(1),)
-        @test @inferred(ArrayInterface.to_parent_dims(typeof(Rr))) === (static(1),)
+    Rr = reinterpret(reshape, Int64, ones(4))
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(Rr))) === (static(1),)
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(Rr))) === (static(1),)
 
-        Sr = reinterpret(reshape, Complex{Int64}, zeros(2, 3, 4))
-        @test @inferred(ArrayInterface.from_parent_dims(typeof(Sr))) === (static(0), static(1), static(2))
-        @test @inferred(ArrayInterface.to_parent_dims(typeof(Sr))) === (static(2), static(3))
-    end
+    Sr = reinterpret(reshape, Complex{Int64}, zeros(2, 3, 4))
+    @test @inferred(ArrayInterface.from_parent_dims(typeof(Sr))) === (static(0), static(1), static(2))
+    @test @inferred(ArrayInterface.to_parent_dims(typeof(Sr))) === (static(2), static(3))
 end
 
 @testset "order_named_inds" begin
@@ -139,7 +137,7 @@ end
     x[x=1] = [2, 3]
     @test @inferred(getindex(x, x=1)) == [2, 3]
     y = NamedDimsWrapper((:x, static(:y)), ones(2, 2))
-    # FIXME this doesn't correctly infer the output because it can't infer 
+    # FIXME this doesn't correctly infer the output because it can't infer
     @test getindex(y, x=1) == [1, 1]
 end
 


### PR DESCRIPTION
We don't need to worry about not having reshaped ReinterpretArray now that LTS is v1.6