### PR TITLE
Use `is_forwarding_wrapper` trait instead of `parent_type(T) <: T`

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -23,10 +23,10 @@ end
 axes_types(x) = axes_types(typeof(x))
 axes_types(::Type{T}) where {T<:Array} = NTuple{ndims(T),OneTo{Int}}
 @inline function axes_types(::Type{T}) where {T}
-    if parent_type(T) <: T
-        return NTuple{ndims(T),OptionallyStaticUnitRange{One,Int}}
-    else
+    if is_forwarding_wrapper(T)
         return axes_types(parent_type(T))
+    else
+        return NTuple{ndims(T),OptionallyStaticUnitRange{One,Int}}
     end
 end
 axes_types(::Type{<:LinearIndices{N,R}}) where {N,R} = R
@@ -207,7 +207,7 @@ end
 
 Base.keys(x::LazyAxis) = keys(parent(x))
 
-Base.IndexStyle(::Type{<:LazyAxis}) = IndexStyle(parent_type(T))
+Base.IndexStyle(T::Type{<:LazyAxis}) = IndexStyle(parent_type(T))
 
 ArrayInterfaceCore.can_change_size(@nospecialize T::Type{<:LazyAxis}) = can_change_size(fieldtype(T, :parent))
 

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -35,6 +35,7 @@ function is_increasing(perm::Tuple{StaticInt{X},StaticInt{Y}}) where {X, Y}
     end
 end
 is_increasing(::Tuple{StaticInt{X}}) where {X} = True()
+is_increasing(::Tuple{}) = True()
 
 """
     from_parent_dims(::Type{T}) -> Tuple{Vararg{Union{Int,StaticInt}}}
@@ -164,13 +165,41 @@ have a name.
 """
 @inline known_dimnames(x, dim) = _known_dimname(known_dimnames(x), canonicalize(dim))
 known_dimnames(x) = known_dimnames(typeof(x))
-known_dimnames(::Type{T}) where {T} = _known_dimnames(T, parent_type(T))
-_known_dimnames(::Type{T}, ::Type{T}) where {T} = _unknown_dimnames(Base.IteratorSize(T))
+function known_dimnames(@nospecialize T::Type{<:VecAdjTrans})
+    (:_, getfield(known_dimnames(parent_type(T)), 1))
+end
+function known_dimnames(@nospecialize T::Type{<:Union{MatAdjTrans,PermutedDimsArray,SubArray}})
+    eachop(_inbounds_known_dimname, to_parent_dims(T), known_dimnames(parent_type(T)))
+end
+# TODO Base.NonReshapedReinterpretArray
+function known_dimnames(@nospecialize T::Type{<:Base.NonReshapedReinterpretArray})
+    known_dimnames(parent_type(T))
+end
+@inline function known_dimnames(@nospecialize T::Type{<:Base.ReshapedArray})
+    if ndims(T) === ndims(parent_type(T))
+        return known_dimnames(parent_type(T))
+    elseif ndims(T) > ndims(parent_type(T))
+        return (known_dimnames(parent_type(T))..., n_of_x(StaticInt(ndims(T) - ndims(parent_type(T))), :_)...)
+    else
+        return n_of_x(StaticInt(ndims(T)), :_)
+    end
+end
+@inline function known_dimnames(::Type{T}) where {T}
+    if is_forwarding_wrapper(T)
+        return known_dimnames(parent_type(T))
+    else
+        return _unknown_dimnames(Base.IteratorSize(T))
+    end
+end
 _unknown_dimnames(::Base.HasShape{N}) where {N} = ntuple(Compat.Returns(:_), Val(N))
 _unknown_dimnames(::Any) = (:_,)
+
+#=
+_known_dimnames(::Type{T}, ::Type{T}) where {T} = _unknown_dimnames(Base.IteratorSize(T))
 function _known_dimnames(::Type{C}, ::Type{P}) where {C,P}
     eachop(_inbounds_known_dimname, to_parent_dims(C), known_dimnames(P))
 end
+=#
 @inline function _known_dimname(x::Tuple{Vararg{Any,N}}, dim::CanonicalInt) where {N}
     # we cannot have `@boundscheck`, else this will depend on bounds checking being enabled
     (dim > N || dim < 1) && return :_
@@ -186,6 +215,22 @@ Return the names of the dimensions for `x`. `:_` is used to indicate a dimension
 have a name.
 """
 @inline dimnames(x, dim) = _dimname(dimnames(x), canonicalize(dim))
+@inline function dimnames(x::Union{MatAdjTrans,PermutedDimsArray,SubArray})
+    eachop(_inbounds_known_dimname, to_parent_dims(x), dimnames(parent(x)))
+end
+dimnames(x::VecAdjTrans) = (static(:_), getfield(dimnames(parent(x)), 1))
+# TODO Base.NonReshapedReinterpretArray
+dimnames(x::Base.NonReshapedReinterpretArray) = dimnames(parent(x))
+@inline function dimnames(x::Base.ReshapedArray)
+    p = parent(x)
+    if ndims(x) === ndims(p)
+        return dimnames(p)
+    elseif ndims(x) > ndims(p)
+        return (dimnames(p)..., n_of_x(StaticInt(ndims(x) - ndims(p)), static(:_))...)
+    else
+        return n_of_x(StaticInt(ndims(x)), static(:_))
+    end
+end
 @inline dimnames(x) = _dimnames(has_parent(x), x)
 @inline function _dimnames(::True, x)
     eachop(_inbounds_dimname, to_parent_dims(x), dimnames(parent(x)))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -318,14 +318,14 @@ end
 
 ## unsafe_getindex ##
 function unsafe_getindex(a::A) where {A}
-    parent_type(A) <: A && throw(MethodError(unsafe_getindex, (A,)))
+    is_forwarding_wrapper(A) || throw(MethodError(unsafe_getindex, (A,)))
     unsafe_getindex(parent(a))
 end
 
 # TODO Need to manage index transformations between nested layers of arrays
 function unsafe_getindex(a::A, i::CanonicalInt) where {A}
     if IndexStyle(A) === IndexLinear()
-        parent_type(A) <: A && throw(MethodError(unsafe_getindex, (A, i)))
+        is_forwarding_wrapper(A) || throw(MethodError(unsafe_getindex, (A, i)))
         return unsafe_getindex(parent(a), i)
     else
         return unsafe_getindex(a, _to_cartesian(a, i)...)
@@ -335,7 +335,7 @@ function unsafe_getindex(a::A, i::CanonicalInt, ii::Vararg{CanonicalInt}) where 
     if IndexStyle(A) === IndexLinear()
         return unsafe_getindex(a, _to_linear(a, (i, ii...)))
     else
-        parent_type(A) <: A && throw(MethodError(unsafe_getindex, (A, i)))
+        is_forwarding_wrapper(A) || throw(MethodError(unsafe_getindex, (A, i)))
         return unsafe_getindex(parent(a), i, ii...)
     end
 end
@@ -415,13 +415,13 @@ end
 
 ## unsafe_setindex! ##
 function unsafe_setindex!(a::A, v) where {A}
-    parent_type(A) <: A && throw(MethodError(unsafe_setindex!, (A, v)))
+    is_forwarding_wrapper(A) || throw(MethodError(unsafe_setindex!, (A, v)))
     return unsafe_setindex!(parent(a), v)
 end
 # TODO Need to manage index transformations between nested layers of arrays
 function unsafe_setindex!(a::A, v, i::CanonicalInt) where {A}
     if IndexStyle(A) === IndexLinear()
-        parent_type(A) <: A && throw(MethodError(unsafe_setindex!, (A, v, i)))
+        is_forwarding_wrapper(A) || throw(MethodError(unsafe_setindex!, (A, v, i)))
         return unsafe_setindex!(parent(a), v, i)
     else
         return unsafe_setindex!(a, v, _to_cartesian(a, i)...)
@@ -431,7 +431,7 @@ function unsafe_setindex!(a::A, v, i::CanonicalInt, ii::Vararg{CanonicalInt}) wh
     if IndexStyle(A) === IndexLinear()
         return unsafe_setindex!(a, v, _to_linear(a, (i, ii...)))
     else
-        parent_type(A) <: A && throw(MethodError(unsafe_setindex!, (A, v, i, ii...)))
+        is_forwarding_wrapper(A) || throw(MethodError(unsafe_setindex!, (A, v, i, ii...)))
         return unsafe_setindex!(parent(a), v, i, ii...)
     end
 end

--- a/src/size.jl
+++ b/src/size.jl
@@ -16,7 +16,13 @@ julia> ArrayInterface.size(A)
 (static(3), static(4))
 ```
 """
-size(a::A) where {A} = _maybe_size(Base.IteratorSize(A), a)
+@inline function size(a::A) where {A}
+    if is_forwarding_wrapper(A)
+        return size(parent(a))
+    else
+        return _maybe_size(Base.IteratorSize(A), a)
+    end
+end
 size(a::Base.Broadcast.Broadcasted) = map(length, axes(a))
 
 _maybe_size(::Base.HasShape{N}, a::A) where {N,A} = map(length, axes(a))

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -164,9 +164,8 @@ function contiguous_axis(::Type{T}) where {T<:PermutedDimsArray}
     end
 end
 function contiguous_axis(::Type{<:Base.ReshapedArray{T, N, A, Tuple{}}}) where {T, N, A}
-    c = contiguous_axis(A)
-    if c === nothing || isone(-c)
-        return c
+    if isone(-contiguous_axis(A))
+        return StaticInt(-1)
     elseif dynamic(is_column_major(A) & is_dense(A))
         return StaticInt(1)
     else

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -127,11 +127,7 @@ contiguous_axis(x) = contiguous_axis(typeof(x))
 contiguous_axis(::Type{<:StrideIndex{N,R,C}}) where {N,R,C} = static(C)
 contiguous_axis(::Type{<:StrideIndex{N,R,nothing}}) where {N,R} = nothing
 function contiguous_axis(::Type{T}) where {T}
-    if parent_type(T) <: T
-        return nothing
-    else
-        return contiguous_axis(parent_type(T))
-    end
+    is_forwarding_wrapper(T) ? contiguous_axis(parent_type(T)) : nothing
 end
 contiguous_axis(::Type{<:DenseArray}) = One()
 contiguous_axis(::Type{<:BitArray}) = One()
@@ -167,17 +163,17 @@ function contiguous_axis(::Type{T}) where {T<:PermutedDimsArray}
         return from_parent_dims(T, c)
     end
 end
-function contiguous_axis(::Type{Base.ReshapedArray{T, 1, A, Tuple{}}}) where {T, A}
-  IfElse.ifelse(is_column_major(A) & is_dense(A), static(1), nothing)
+function contiguous_axis(::Type{<:Base.ReshapedArray{T, N, A, Tuple{}}}) where {T, N, A}
+  IfElse.ifelse(is_column_major(A) & is_dense(A), static(1), static(-1))
 end
-function contiguous_axis(::Type{Base.ReshapedArray{T, 1, LinearAlgebra.Adjoint{T, A}, Tuple{}}}) where {T, A <: AbstractVector{T}}
-  IfElse.ifelse(is_column_major(A) & is_dense(A), static(1), nothing)
+function contiguous_axis(::Type{<:Base.ReshapedArray{T, 1, LinearAlgebra.Adjoint{T, A}, Tuple{}}}) where {T, A <: AbstractVector{T}}
+  IfElse.ifelse(is_column_major(A) & is_dense(A), static(1), static(-1))
 end
-function contiguous_axis(::Type{Base.ReshapedArray{T, 1, LinearAlgebra.Transpose{T, A}, Tuple{}}}) where {T, A <: AbstractVector{T}}
-  IfElse.ifelse(is_column_major(A) & is_dense(A), static(1), nothing)
+function contiguous_axis(::Type{<:Base.ReshapedArray{T, 1, LinearAlgebra.Transpose{T, A}, Tuple{}}}) where {T, A <: AbstractVector{T}}
+  IfElse.ifelse(is_column_major(A) & is_dense(A), static(1), static(-1))
 end
 function contiguous_axis(::Type{T}) where {T<:SubArray}
-    return _contiguous_axis(T, contiguous_axis(parent_type(T)))
+    _contiguous_axis(T, contiguous_axis(parent_type(T)))
 end
 
 _contiguous_axis(::Type{A}, ::Nothing) where {T,N,P,I,A<:SubArray{T,N,P,I}} = nothing
@@ -230,11 +226,7 @@ end
 stride_rank(::Type{<:StrideIndex{N,R}}) where {N,R} = static(R)
 stride_rank(x) = stride_rank(typeof(x))
 function stride_rank(::Type{T}) where {T}
-    if parent_type(T) <: T
-        return nothing
-    else
-        return stride_rank(parent_type(T))
-    end
+    is_forwarding_wrapper(T) ? stride_rank(parent_type(T)) : nothing
 end
 stride_rank(::Type{<:DenseArray{T,N}}) where {T,N} = nstatic(Val(N))
 stride_rank(::Type{BitArray{N}}) where {N} = nstatic(Val(N))
@@ -370,11 +362,7 @@ where `stride_rank(A)[i] + 1 == stride_rank(A)[j]`.
 """
 dense_dims(x) = dense_dims(typeof(x))
 function dense_dims(::Type{T}) where {T}
-    if parent_type(T) <: T
-        return nothing
-    else
-        return dense_dims(parent_type(T))
-    end
+    is_forwarding_wrapper(T) ? dense_dims(parent_type(T)) : nothing
 end
 _all_dense(::Val{N}) where {N} = ntuple(_ -> True(), Val{N}())
 
@@ -412,6 +400,9 @@ end
 @inline function dense_dims(::Type{A}) where {NB, NA, B <: AbstractArray{<:Any,NB},A<: Base.ReinterpretArray{<:Any, NA, <:Any, B, true}}
     ddb = dense_dims(B)
     IfElse.ifelse(Static.le(StaticInt(NB), StaticInt(NA)), (True(), ddb...), Base.tail(ddb))
+end
+@inline function dense_dims(::Type{A}) where {NB, NA, B <: AbstractArray{<:Any,NB},A<: Base.ReinterpretArray{<:Any, NA, <:Any, B, false}}
+    dense_dims(B)
 end
 
 _dense_dims(::Type{S}, ::Nothing, ::Val{R}) where {R,N,NP,T,A<:AbstractArray{T,NP},I,S<:SubArray{T,N,A,I}} = nothing
@@ -462,10 +453,11 @@ _is_dense(::Tuple{False,Vararg}) = False()
 _is_dense(t::Tuple{True,Vararg}) = _is_dense(Base.tail(t))
 _is_dense(t::Tuple{True}) = True()
 _is_dense(t::Tuple{}) = True()
+_is_dense(::Nothing) = False()
 
 
 _reshaped_dense_dims(_, __, ___, ____) = nothing
-function _reshaped_dense_dims(dense::D, ::True, ::Val{N}, ::Val{0}) where {D,N}
+function _reshaped_dense_dims(dense::Tuple, ::True, ::Val{N}, ::Val{0}) where {N}
     if all(dense)
         return _all_dense(Val{N}())
     else
@@ -498,17 +490,17 @@ known_strides(::Type{<:StrideIndex{N,R,C,S,O}}) where {N,R,C,S,O} = known(S)
 known_strides(x) = known_strides(typeof(x))
 known_strides(::Type{T}) where {T<:Vector} = (1,)
 function known_strides(::Type{T}) where {T<:MatAdjTrans}
-    return permute(known_strides(parent_type(T)), to_parent_dims(T))
+    permute(known_strides(parent_type(T)), to_parent_dims(T))
 end
 @inline function known_strides(::Type{T}) where {T<:VecAdjTrans}
     strd = first(known_strides(parent_type(T)))
     return (strd, strd)
 end
 @inline function known_strides(::Type{T}) where {T<:PermutedDimsArray}
-    return permute(known_strides(parent_type(T)), to_parent_dims(T))
+    permute(known_strides(parent_type(T)), to_parent_dims(T))
 end
 @inline function known_strides(::Type{T}) where {T<:SubArray}
-    return permute(known_strides(parent_type(T)), to_parent_dims(T))
+    permute(known_strides(parent_type(T)), to_parent_dims(T))
 end
 function known_strides(::Type{T}) where {T}
     if ndims(T) === 1
@@ -548,7 +540,7 @@ strides(A::StrideIndex) = getfield(A, :strides)
 @inline strides(A::Vector{<:Any}) = (StaticInt(1),)
 @inline strides(A::Array{<:Any,N}) where {N} = (StaticInt(1), Base.tail(Base.strides(A))...)
 @inline function strides(x::X) where {X}
-    if !(parent_type(X) <: X)
+    if is_forwarding_wrapper(X)
         return strides(parent(x))
     elseif defines_strides(X)
         return size_to_strides(size(x), One())
@@ -558,21 +550,25 @@ strides(A::StrideIndex) = getfield(A, :strides)
 end
 
 _is_column_dense(::A) where {A<:AbstractArray} =
-    defines_strides(A) && 
+    defines_strides(A) &&
     (ndims(A) == 0 || Bool(is_dense(A)) && Bool(is_column_major(A)))
 
 # Fixes the example of https://github.com/JuliaArrays/ArrayInterfaceCore.jl/issues/160
 function strides(A::ReshapedArray)
-    _is_column_dense(parent(A)) && return size_to_strides(size(A), One())
-    pst = strides(parent(A))
-    psz = size(parent(A))
-    # Try dimension merging in order (starting from dim1).
-    # `sz1` and `st1` are the `size`/`stride` of dim1 after dimension merging.
-    # `n` indicates the last merged dimension.
-    # note: `st1` should be static if possible
-    sz1, st1, n = merge_adjacent_dim(psz, pst)
-    n == ndims(A.parent) && return size_to_strides(size(A), st1)
-    return _reshaped_strides(size(A), One(), sz1, st1, n, Dims(psz), Dims(pst))
+    if defines_strides(parent(A)) && (ndims(A) == 0 || Bool(is_dense(A)) && Bool(is_column_major(A)))
+        return size_to_strides(size(A), One())
+    else
+        pst = strides(parent(A))
+        psz = size(parent(A))
+        # Try dimension merging in order (starting from dim1).
+        # `sz1` and `st1` are the `size`/`stride` of dim1 after dimension merging.
+        # `n` indicates the last merged dimension.
+        # note: `st1` should be static if possible
+        sz1, st1, n = merge_adjacent_dim(psz, pst)
+        n == ndims(A.parent) && return size_to_strides(size(A), st1)
+        n == ndims(A.parent) && return size_to_strides(size(A), st1)
+        return _reshaped_strides(size(A), One(), sz1, st1, n, Dims(psz), Dims(pst))
+    end
 end
 
 @inline function _reshaped_strides(::Dims{0}, reshaped, msz::Int, _, ::Int, ::Dims, ::Dims)
@@ -613,7 +609,7 @@ function merge_adjacent_dim(szs::Tuple, sts::Tuple)
     else # the check can't be done during compiling.
         sz, st, n = merge_adjacent_dim(Dims(szs), Dims(sts), 1)
         if (szs[1], sts[1]) isa NTuple{2,StaticInt} && szs[1] != 1
-            # But the 1st stride might still be static. 
+            # But the 1st stride might still be static.
             return sz, sts[1], n
         else
             return sz, st, n
@@ -717,10 +713,10 @@ end
 
 strides(a, dim) = strides(a, to_dims(a, dim))
 function strides(a::A, dim::CanonicalInt) where {A}
-    if parent_type(A) <: A
-        return Base.stride(a, Int(dim))
-    else
+    if is_forwarding_wrapper(A)
         return strides(parent(a), to_parent_dims(A, dim))
+    else
+        return Base.stride(a, Int(dim))
     end
 end
 

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -566,7 +566,6 @@ function strides(A::ReshapedArray)
         # note: `st1` should be static if possible
         sz1, st1, n = merge_adjacent_dim(psz, pst)
         n == ndims(A.parent) && return size_to_strides(size(A), st1)
-        n == ndims(A.parent) && return size_to_strides(size(A), st1)
         return _reshaped_strides(size(A), One(), sz1, st1, n, Dims(psz), Dims(pst))
     end
 end

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -70,9 +70,14 @@ end
 
 @testset "ArrayInterface.dimnames" begin
     d = (static(:x), static(:y))
-    x = NamedDimsWrapper(d, ones(2, 2))
+    x = NamedDimsWrapper(d, ones(Int64, 2, 2))
     y = NamedDimsWrapper((static(:x),), ones(2))
     z = NamedDimsWrapper((:x, static(:y)), ones(2))
+    r1 = reinterpret(Int8, x)
+    r2 = reinterpret(reshape, Int8, x)
+    r3 = reinterpret(reshape, Complex{Int}, x)
+    r4 = reinterpret(reshape, Float64, x)
+    w = Wrapper(x)
     dnums = ntuple(+, length(d))
     @test @inferred(ArrayInterface.has_dimnames(x)) == true
     @test @inferred(ArrayInterface.has_dimnames(z)) == true
@@ -81,6 +86,11 @@ end
     @test @inferred(ArrayInterface.has_dimnames(typeof(x))) == true
     @test @inferred(ArrayInterface.has_dimnames(typeof(view(x, :, 1, :)))) == true
     @test @inferred(ArrayInterface.dimnames(x)) === d
+    @test @inferred(ArrayInterface.dimnames(w)) === d
+    @test @inferred(ArrayInterface.dimnames(r1)) === d
+    @test @inferred(ArrayInterface.dimnames(r2)) === (static(:_), d...)
+    @test @inferred(ArrayInterface.dimnames(r3)) === Base.tail(d)
+    @test @inferred(ArrayInterface.dimnames(r4)) === d
     @test @inferred(ArrayInterface.ArrayInterface.dimnames(z)) === (:x, static(:y))
     @test @inferred(ArrayInterface.dimnames(parent(x))) === (static(:_), static(:_))
     @test @inferred(ArrayInterface.dimnames(reshape(x, (1, 4)))) === d
@@ -99,6 +109,11 @@ end
     @test @inferred(ArrayInterface.known_dimnames(Iterators.flatten(1:10), static(1))) === :_
     @test @inferred(ArrayInterface.known_dimnames(z)) === (nothing, :y)
     @test @inferred(ArrayInterface.known_dimnames(reshape(x, (1, 4)))) == d
+    @test @inferred(ArrayInterface.known_dimnames(r1)) == d
+    @test @inferred(ArrayInterface.known_dimnames(r2)) == (:_, d...)
+    @test @inferred(ArrayInterface.known_dimnames(r3)) == Base.tail(d)
+    @test @inferred(ArrayInterface.known_dimnames(r4)) == d
+    @test @inferred(ArrayInterface.known_dimnames(w)) == d
     @test @inferred(ArrayInterface.known_dimnames(reshape(x, :))) === (:_,)
     @test @inferred(ArrayInterface.known_dimnames(view(x, :, 1)')) === (:_, :x)
 end

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -83,11 +83,14 @@ end
     @test @inferred(ArrayInterface.dimnames(x)) === d
     @test @inferred(ArrayInterface.ArrayInterface.dimnames(z)) === (:x, static(:y))
     @test @inferred(ArrayInterface.dimnames(parent(x))) === (static(:_), static(:_))
+    @test @inferred(ArrayInterface.dimnames(reshape(x, (1, 4)))) === d
+    @test @inferred(ArrayInterface.dimnames(reshape(x, :))) === (static(:_),)
     @test @inferred(ArrayInterface.dimnames(x')) === reverse(d)
     @test @inferred(ArrayInterface.dimnames(y')) === (static(:_), static(:x))
     @test @inferred(ArrayInterface.dimnames(PermutedDimsArray(x, (2, 1)))) === reverse(d)
     @test @inferred(ArrayInterface.dimnames(PermutedDimsArray(x', (2, 1)))) === d
     @test @inferred(ArrayInterface.dimnames(view(x, :, 1))) === (static(:x),)
+    @test @inferred(ArrayInterface.dimnames(view(x, :, 1)')) === (static(:_), static(:x))
     @test @inferred(ArrayInterface.dimnames(view(x, :, :, :))) === (static(:x), static(:y), static(:_))
     @test @inferred(ArrayInterface.dimnames(view(x, :, 1, :))) === (static(:x), static(:_))
     @test @inferred(ArrayInterface.dimnames(x, ArrayInterface.One())) === static(:x)
@@ -95,6 +98,9 @@ end
     @test @inferred(ArrayInterface.known_dimnames(Iterators.flatten(1:10))) === (:_,)
     @test @inferred(ArrayInterface.known_dimnames(Iterators.flatten(1:10), static(1))) === :_
     @test @inferred(ArrayInterface.known_dimnames(z)) === (nothing, :y)
+    @test @inferred(ArrayInterface.known_dimnames(reshape(x, (1, 4)))) == d
+    @test @inferred(ArrayInterface.known_dimnames(reshape(x, :))) === (:_,)
+    @test @inferred(ArrayInterface.known_dimnames(view(x, :, 1)')) === (:_, :x)
 end
 
 @testset "to_dims" begin
@@ -139,28 +145,4 @@ end
     y = NamedDimsWrapper((:x, static(:y)), ones(2, 2))
     # FIXME this doesn't correctly infer the output because it can't infer
     @test getindex(y, x=1) == [1, 1]
-end
-
-@testset "Reshaped views" begin
-    u_base = randn(10, 10)
-    u_view = view(u_base, 3, :)
-    u_reshaped_view1 = reshape(u_view, 1, :)
-    u_reshaped_view2 = reshape(u_view, 2, :)
-
-    @test @inferred(ArrayInterface.defines_strides(u_base))
-    @test @inferred(ArrayInterface.defines_strides(u_view))
-    @test @inferred(ArrayInterface.defines_strides(u_reshaped_view1))
-    @test @inferred(ArrayInterface.defines_strides(u_reshaped_view2))
-
-    # See https://github.com/JuliaArrays/ArrayInterface.jl/issues/160
-    @test @inferred(ArrayInterface.strides(u_base)) == (StaticInt(1), 10)
-    @test @inferred(ArrayInterface.strides(u_view)) == (10,)
-    @test @inferred(ArrayInterface.strides(u_reshaped_view1)) == (10, 10)
-    @test @inferred(ArrayInterface.strides(u_reshaped_view2)) == (10, 20)
-
-    # See https://github.com/JuliaArrays/ArrayInterface.jl/issues/157
-    @test @inferred(ArrayInterface.dense_dims(u_base)) == (True(), True())
-    @test @inferred(ArrayInterface.dense_dims(u_view)) == (False(),)
-    @test @inferred(ArrayInterface.dense_dims(u_reshaped_view1)) == (False(), False())
-    @test @inferred(ArrayInterface.dense_dims(u_reshaped_view2)) == (False(), False())
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -6,7 +6,6 @@ struct MArray{T,N,R} <: DenseArray{T,N}
 end
 
 MArray(A::Array) = MArray(A, LinearIndices(map(s -> static(1):static(s), size(A))))
-
 Base.parent(x::MArray) = x.parent
 Base.IndexStyle(::Type{<:MArray}) = IndexLinear()
 ArrayInterface.axes(x::MArray) = ArrayInterface.axes(x.indices)
@@ -27,6 +26,7 @@ struct NamedDimsWrapper{D,T,N,P<:AbstractArray{T,N}} <: ArrayInterface.AbstractA
     parent::P
     NamedDimsWrapper(d::D, p::P) where {D,P} = new{D,eltype(P),ndims(p),P}(d, p)
 end
+ArrayInterface.is_forwarding_wrapper(::Type{<:NamedDimsWrapper}) = true
 Base.parent(x::NamedDimsWrapper) = getfield(x, :parent)
 ArrayInterface.parent_type(::Type{T}) where {P,T<:NamedDimsWrapper{<:Any,<:Any,<:Any,P}} = P
 ArrayInterface.dimnames(x::NamedDimsWrapper) = getfield(x, :dimnames)
@@ -50,8 +50,7 @@ struct Wrapper{T,N,P<:AbstractArray{T,N}} <: ArrayInterface.AbstractArray2{T,N}
 end
 ArrayInterface.parent_type(::Type{<:Wrapper{T,N,P}}) where {T,N,P} = P
 Base.parent(x::Wrapper) = x.parent
-ArrayInterface.device(::Type{T}) where {T<:Wrapper} = ArrayInterface.device(ArrayInterface.parent_type(T))
+ArrayInterface.is_forwarding_wrapper(::Type{<:Wrapper}) = true
 
 struct DenseWrapper{T,N,P<:AbstractArray{T,N}} <: DenseArray{T,N} end
 ArrayInterface.parent_type(::Type{DenseWrapper{T,N,P}}) where {T,N,P} = P
-

--- a/test/stridelayout.jl
+++ b/test/stridelayout.jl
@@ -346,3 +346,27 @@ end
     @test @inferred(ArrayInterface.strides(reshape(view(a, static(1):static(2), static(1):static(4), 1:3), 2, 2, 2, 3))) === (static(1), 3, 6, 15)
     @test @inferred(ArrayInterface.strides(reshape(view(a, static(1):static(2), static(1):static(1), 1:3), 2, 1, 3))) === (static(1), 2, 15)
 end
+
+@testset "Reshaped views" begin
+    u_base = randn(10, 10)
+    u_view = view(u_base, 3, :)
+    u_reshaped_view1 = reshape(u_view, 1, :)
+    u_reshaped_view2 = reshape(u_view, 2, :)
+
+    @test @inferred(ArrayInterface.defines_strides(u_base))
+    @test @inferred(ArrayInterface.defines_strides(u_view))
+    @test @inferred(ArrayInterface.defines_strides(u_reshaped_view1))
+    @test @inferred(ArrayInterface.defines_strides(u_reshaped_view2))
+
+    # See https://github.com/JuliaArrays/ArrayInterface.jl/issues/160
+    @test @inferred(ArrayInterface.strides(u_base)) == (StaticInt(1), 10)
+    @test @inferred(ArrayInterface.strides(u_view)) == (10,)
+    @test @inferred(ArrayInterface.strides(u_reshaped_view1)) == (10, 10)
+    @test @inferred(ArrayInterface.strides(u_reshaped_view2)) == (10, 20)
+
+    # See https://github.com/JuliaArrays/ArrayInterface.jl/issues/157
+    @test @inferred(ArrayInterface.dense_dims(u_base)) == (True(), True())
+    @test @inferred(ArrayInterface.dense_dims(u_view)) == (False(),)
+    @test @inferred(ArrayInterface.dense_dims(u_reshaped_view1)) == (False(), False())
+    @test @inferred(ArrayInterface.dense_dims(u_reshaped_view2)) == (False(), False())
+end

--- a/test/stridelayout.jl
+++ b/test/stridelayout.jl
@@ -266,7 +266,7 @@ end
     @test @inferred(ArrayInterface.dense_dims(view(DummyZeros(3,4), :, 1)')) === nothing
     @test @inferred(ArrayInterface.is_dense(A)) === @inferred(ArrayInterface.is_dense(A)) === @inferred(ArrayInterface.is_dense(PermutedDimsArray(A,(3,1,2)))) === @inferred(ArrayInterface.is_dense(Array{Float64,0}(undef))) === True()
     @test @inferred(ArrayInterface.is_dense(@view(PermutedDimsArray(A,(3,1,2))[2:3,1:2,:]))) === @inferred(ArrayInterface.is_dense(@view(PermutedDimsArray(A,(3,1,2))[2:3,:,[1,2]]))) === @inferred(ArrayInterface.is_dense(@view(PermutedDimsArray(A,(3,1,2))[2:3,[1,2,3],:]))) === False()
-  
+
     C = Array{Int8}(undef, 2,2,2,2);
     doubleperm = PermutedDimsArray(PermutedDimsArray(C,(4,2,3,1)), (4,2,1,3));
     @test collect(strides(C))[collect(ArrayInterface.stride_rank(doubleperm))] == collect(strides(doubleperm))
@@ -332,8 +332,8 @@ end
     @test @inferred(ArrayInterface.strides(vec(view(a, 1, 1)))) === (static(1),)
     @test_throws ArgumentError ArrayInterface.strides(reshape(view(a, :, 1:2:9), 5, 5, 2))
     a = MArray(randn(10, 10))
-    @test @inferred(ArrayInterface.strides(reshape(view(a, 1:9, 1:10), 3, 3, 2, 5))) === (1, 3, 10, 20) 
-    @test @inferred(ArrayInterface.strides(reshape(view(a, static(1):static(9), 1:10), 3, 3, 2, 5))) === (static(1), 3, 10, 20) 
+    @test @inferred(ArrayInterface.strides(reshape(view(a, 1:9, 1:10), 3, 3, 2, 5))) === (1, 3, 10, 20)
+    @test @inferred(ArrayInterface.strides(reshape(view(a, static(1):static(9), 1:10), 3, 3, 2, 5))) === (static(1), 3, 10, 20)
     @test @inferred(ArrayInterface.strides(reshape(view(a, :, 1:2:9), 2, 5, 5))) === (static(1), 2, 20)
     a = randn(2, 5, 3)
     @test @inferred(ArrayInterface.strides(vec(view(a, :, 1:5, 1:3)))) === (1,)


### PR DESCRIPTION
Using the heuristic `parent_type(T) <: T` sometimes gives incorrect results and may hide holes in the interface (as I found when making these changes).

Some problems I found:

* `is_increasing(stride_rank(A))` didn't account for `A` having zero dimensions
* `is_dense(A)` didn't know how to handle when `dense_dims(A)` returned `nothing`.
* `contiguous_axis(::Type{<:ReshapedArray})` would sometimes return `nothing` (meaning the contiguous axis is unknown) instead of `StaticInt(-1)` when we actually knew there couldn't be a contiguous axis because it didn't exist in the parent array.
* `(known)_dimnames(A)` was often returning incorrect results for `ReinterpretArray` and `ReshapedArray`.

