### PR TITLE
Quick fix for getting axes on SubArray with multidim indices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.12"
+version = "6.0.13"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/test/axes.jl
+++ b/test/axes.jl
@@ -66,6 +66,10 @@ end
     @test @inferred(ArrayInterface.axes(b, static(1))) == 1:m
     @test @inferred(ArrayInterface.axes(b, static(2))) == 1:1
     @test @inferred(ArrayInterface.axes(b, static(3))) == 1:1
+
+    # multidimensional subindices
+    vx = view(rand(4), reshape(1:4, 2, 2))
+    @test @inferred(axes(vx)) == (1:2, 1:2)
 end
 
 @testset "SubArray Adjoint Axis" begin


### PR DESCRIPTION
Errors/inconsistencies occur when doing 'to_parent_dims(view(rand(4), reshape(1:4, 2, 2)))'. Up to this point we haven't really worried about sub indices with multiple dimensions because it's difficult to turn that into any useful information for the stuff in "stridelayout.jl".

I probably need to replace/rework the `to_parent_dims` method to avoid similar issues in the future.