### PR TITLE
fix non-reshapred reinterpretarray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.14"
+version = "6.0.15"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -261,8 +261,15 @@ end
 @inline function stride_rank(::Type{A}) where {NB,NA,B<:AbstractArray{<:Any,NB},A<:Base.ReinterpretArray{<:Any,NA,<:Any,B,true}}
     NA == NB ? stride_rank(B) : _stride_rank_reinterpret(stride_rank(B), gt(StaticInt{NB}(), StaticInt{NA}()))
 end
+@inline function stride_rank(::Type{A}) where {N,B<:AbstractArray{<:Any,N},A<:Base.ReinterpretArray{<:Any,N,<:Any,B,false}}
+    stride_rank(B)
+end
+
 @inline _stride_rank_reinterpret(sr, ::False) = (One(), map(Base.Fix2(+, One()), sr)...)
 @inline _stride_rank_reinterpret(sr::Tuple{One,Vararg}, ::True) = map(Base.Fix2(-, One()), tail(sr))
+function contiguous_axis(::Type{R}) where {T,N,S,B<:AbstractArray{S,N},R<:ReinterpretArray{T,N,S,B,false}}
+    contiguous_axis(B)
+end
 # if the leading dim's `stride_rank` is not one, then that means the individual elements are split across an axis, which ArrayInterface
 # doesn't currently have a means of representing.
 @inline function contiguous_axis(::Type{A}) where {NB,NA,B<:AbstractArray{<:Any,NB},A<:Base.ReinterpretArray{<:Any,NA,<:Any,B,true}}

--- a/test/stridelayout.jl
+++ b/test/stridelayout.jl
@@ -108,6 +108,11 @@ end
     @test @inferred(ArrayInterface.strides(Ac2t)) === (StaticInt(1), 5)
     Ac2t_static = reinterpret(reshape, Tuple{Float64,Float64}, view(MArray(rand(ComplexF64, 5, 7)), 2:4, 3:6));
     @test @inferred(ArrayInterface.strides(Ac2t_static)) === (StaticInt(1), StaticInt(5))
+
+    a = rand(Float32, 100, 2);
+    b = reinterpret(Float64, view(a,:,1));
+    @test @inferred(ArrayInterface.contiguous_axis(a)) === StaticInt(1)
+    @test @inferred(ArrayInterface.stride_rank(b)) === (StaticInt(1),)
 end
 
 @testset "Memory Layout" begin


### PR DESCRIPTION
There was a regression introduced because `Base.ReinterpretArray`s aren't considered forwarding wrappers, which several methods were relying on.