### PR TITLE
Remove unnecessary methods from `setindex`

### DIFF
--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -121,16 +121,6 @@ function Base.setindex(x::AbstractArray, v, i...)
     return _x
 end
 
-function Base.setindex(x::AbstractVector, v, i::Int)
-    n = length(x)
-    x .* (i .!== 1:n) .+ v .* (i .== 1:n)
-end
-
-function Base.setindex(x::AbstractMatrix, v, i::Int, j::Int)
-    n, m = Base.size(x)
-    x .* (i .!== 1:n) .* (j .!== i:m)' .+ v .* (i .== 1:n) .* (j .== i:m)'
-end
-
 """
     can_setindex(::Type{T}) -> Bool
 

--- a/lib/ArrayInterfaceCore/test/runtests.jl
+++ b/lib/ArrayInterfaceCore/test/runtests.jl
@@ -211,6 +211,11 @@ end
         @test iszero(x)
         @test all(isone, y2)
     end
+
+    @testset "string" begin
+        x = fill("a", 2, 3)
+        @test setindex(x, "b", 2, 1) == setindex(x, "b", CartesianIndex(2, 1)) == ["a" "a" "a";"b" "a" "a"]
+    end
 end
 
 @testset "Sparsity Structure" begin


### PR DESCRIPTION
The current implementation of `setindex` is problematic for the following reasons:

* It is not compatible with `OffsetArrays`.
* It is not compatible with non-numeric types such as `Array{string}`.
* It will produce ambiguities with StaticArrays.jl (https://github.com/JuliaArrays/StaticArrays.jl/issues/1039).

---

**Before this PR**
```julia
julia> using ArrayInterface

julia> x = fill("a", 2, 3)
2×3 Matrix{String}:
 "a"  "a"  "a"
 "a"  "a"  "a"

julia> Base.setindex(x, "b", 2, 1)
ERROR: DimensionMismatch("arrays could not be broadcast to a common size; got a dimension with lengths 3 and 2")
Stacktrace:
  [1] _bcs1
    @ ./broadcast.jl:516 [inlined]
  [2] _bcs (repeats 2 times)
    @ ./broadcast.jl:510 [inlined]
  [3] broadcast_shape
    @ ./broadcast.jl:504 [inlined]
  [4] combine_axes
    @ ./broadcast.jl:499 [inlined]
  [5] _axes
    @ ./broadcast.jl:224 [inlined]
  [6] axes
    @ ./broadcast.jl:222 [inlined]
  [7] combine_axes
    @ ./broadcast.jl:499 [inlined]
  [8] instantiate
    @ ./broadcast.jl:281 [inlined]
  [9] materialize
    @ ./broadcast.jl:860 [inlined]
 [10] setindex(x::Matrix{String}, v::String, i::Int64, j::Int64)
    @ ArrayInterfaceCore ~/.julia/packages/ArrayInterfaceCore/wwYvJ/src/ArrayInterfaceCore.jl:131
 [11] top-level scope
    @ REPL[4]:1
```

**After this PR**
```julia
julia> using ArrayInterface

julia> x = fill("a", 2, 3)
2×3 Matrix{String}:
 "a"  "a"  "a"
 "a"  "a"  "a"

julia> Base.setindex(x, "b", 2, 1)
2×3 Matrix{String}:
 "a"  "a"  "a"
 "b"  "a"  "a"
```

---

**Before this PR**
```julia
julia> x = fill(10., 5)
5-element Vector{Float64}:
 10.0
 10.0
 10.0
 10.0
 10.0

julia> @benchmark Base.setindex(x, 2., 2)
BenchmarkTools.Trial: 10000 samples with 986 evaluations.
 Range (min … max):  51.406 ns …  1.120 μs  ┊ GC (min … max): 0.00% … 93.28%
 Time  (median):     53.611 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   56.940 ns ± 46.035 ns  ┊ GC (mean ± σ):  3.58% ±  4.23%

   ▄▆██▇▆▄▂▁▁▁▁▁                                ▁             ▂
  ▇██████████████▇▇▅▅▆▄▅▅▃▃▄▅▃▁▄▁▃▃▁▃▁▁▃▁▁▁▄▆███████▇▆▆▆▆▇█▇█ █
  51.4 ns      Histogram: log(frequency) by time      81.3 ns <

 Memory estimate: 96 bytes, allocs estimate: 1.
```

**After this PR**
```julia
julia> x = fill(10., 5)
5-element Vector{Float64}:
 10.0
 10.0
 10.0
 10.0
 10.0

julia> @benchmark Base.setindex(x, 2., 2)
BenchmarkTools.Trial: 10000 samples with 991 evaluations.
 Range (min … max):  41.592 ns …  1.076 μs  ┊ GC (min … max): 0.00% … 95.34%
 Time  (median):     48.921 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   51.771 ns ± 43.928 ns  ┊ GC (mean ± σ):  3.77% ±  4.25%

  ▂▂▃▃▁    ▂▅▇█▇▆▃▂▁▂▁▁                           ▁▁          ▂
  █████▇▆▅▆█████████████▇▇▆▆▅▅▆▅▃▁▅▄▄▄▄▄▆▃▃▃▄▅▆▇██████▇▆▆▆▇▇▇ █
  41.6 ns      Histogram: log(frequency) by time      75.6 ns <

 Memory estimate: 96 bytes, allocs estimate: 1.
```


