### PR TITLE
Avoid ReshapedArray error when `contiguous_axis` is `nothing` and fix `dense_dims`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "6.0.16"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-ArrayInterfaceStaticArrays = "b0d46f97-bff5-4637-a19a-dd75974142cd"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.15"
+version = "6.0.16"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
+ArrayInterfaceStaticArrays = "b0d46f97-bff5-4637-a19a-dd75974142cd"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -164,7 +164,8 @@ function contiguous_axis(::Type{T}) where {T<:PermutedDimsArray}
     end
 end
 function contiguous_axis(::Type{<:Base.ReshapedArray{T, N, A, Tuple{}}}) where {T, N, A}
-    if isone(-contiguous_axis(A))
+    c = contiguous_axis(A)
+    if c !== nothing && isone(-c)
         return StaticInt(-1)
     elseif dynamic(is_column_major(A) & is_dense(A))
         return StaticInt(1)

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -456,9 +456,17 @@ _dense_dims(::Type{S}, ::Nothing, ::Val{R}) where {R,N,NP,T,A<:AbstractArray{T,N
     end
 end
 
-function dense_dims(::Type{Base.ReshapedArray{T, N, P, Tuple{Vararg{Base.SignedMultiplicativeInverse{Int},M}}}}) where {T,N,P,M}
-    return _reshaped_dense_dims(dense_dims(P), is_column_major(P), Val{N}(), Val{M}())
+function dense_dims(T::Type{<:Base.ReshapedArray})
+    d = dense_dims(parent_type(T))
+    if d === nothing
+        return nothing
+    elseif all(d)
+        return n_of_x(StaticInt(ndims(T)), True())
+    else
+        return n_of_x(StaticInt(ndims(T)), False())
+    end
 end
+                
 is_dense(A) = is_dense(typeof(A))
 is_dense(::Type{A}) where {A} = _is_dense(dense_dims(A))
 _is_dense(::Tuple{False,Vararg}) = False()
@@ -466,19 +474,6 @@ _is_dense(t::Tuple{True,Vararg}) = _is_dense(Base.tail(t))
 _is_dense(t::Tuple{True}) = True()
 _is_dense(t::Tuple{}) = True()
 _is_dense(::Nothing) = False()
-
-
-_reshaped_dense_dims(_, __, ___, ____) = nothing
-function _reshaped_dense_dims(dense::Tuple, ::True, ::Val{N}, ::Val{0}) where {N}
-    if all(dense)
-        return _all_dense(Val{N}())
-    else
-        return nothing
-    end
-end
-function _reshaped_dense_dims(dense::Tuple{Static.False}, ::True, ::Val{N}, ::Val{0}) where {N}
-    return return ntuple(_ -> False(), Val{N}())
-end
 
 """
     known_strides(::Type{T}) -> Tuple

--- a/test/stridelayout.jl
+++ b/test/stridelayout.jl
@@ -160,6 +160,7 @@ end
     @test @inferred(ArrayInterface.contiguous_axis((3,4))) === StaticInt(1)
     @test @inferred(ArrayInterface.contiguous_axis(rand(4)')) === StaticInt(2)
     @test @inferred(ArrayInterface.contiguous_axis(view(@view(PermutedDimsArray(A,(3,1,2))[2:3,2,:])', :, 1)')) === StaticInt(-1)
+    @test @inferred(ArrayInterface.contiguous_axis(reshape(DummyZeros(3,4), (4, 3)))) === nothing
     @test @inferred(ArrayInterface.contiguous_axis(DummyZeros(3,4))) === nothing
     @test @inferred(ArrayInterface.contiguous_axis(PermutedDimsArray(DummyZeros(3,4), (2, 1)))) === nothing
     @test @inferred(ArrayInterface.contiguous_axis(view(DummyZeros(3,4), 1, :))) === nothing

--- a/test/stridelayout.jl
+++ b/test/stridelayout.jl
@@ -260,6 +260,7 @@ end
     @test @inferred(ArrayInterface.dense_dims(@view(PermutedDimsArray(A,(3,1,2))[:,1:2,1])')) == (true,false)
     @test @inferred(ArrayInterface.dense_dims(@view(PermutedDimsArray(A,(3,1,2))[2:3,:,[1,2]]))) == (false,true,false)
     @test @inferred(ArrayInterface.dense_dims(@view(PermutedDimsArray(A,(3,1,2))[2:3,[1,2,3],:]))) == (false,false,false)
+    @test @inferred(ArrayInterface.dense_dims(reshape(view(randn(10, 10, 10), 3, :, :), 1, 100))) == (false, false)
     # TODO Currently Wrapper can't function the same as Array because Array can change
     # the dimensions on reshape. We should be rewrapping the result in `Wrapper` but we
     # first need to develop a standard method for reconstructing arrays


### PR DESCRIPTION
This is intended to fix #304. There were two examples where we had errors in that PR.

This is what I get with this PR.

```julia
julia> n = 4;

julia> u_plain = randn(1, n, n, 1);

julia> u_vectors = reshape(reinterpret(Tuple{eltype(u_plain)}, u_plain), n, n, 1);

julia> u_view = view(u_vectors, :, 1, 1);

julia> u_final = reshape(reinterpret(eltype(u_plain), u_view), 1, length(u_view));

julia> ArrayInterface.StrideIndex(u_final)
ArrayInterface.StrideIndex{2, (1, 2), 1, Tuple{Static.StaticInt{1}, Int64}, Tuple{Static.StaticInt{1}, Static.StaticInt{1}}}((static(1), 1), (static(1), static(1)))
```

and...

```julia
julia> ArrayInterface.contiguous_axis(Base.ReshapedArray{Float64, 2,
    Base.ReinterpretArray{Float64, 1,
         StaticArrays.SVector{1, Float64},
            SubArray{StaticArrays.SVector{1, Float64}, 1,
                Base.ReshapedArray{StaticArrays.SVector{1, Float64}, 3,
                    Base.ReinterpretArray{
                        StaticArrays.SVector{1, Float64}, 4, Float64,
                        Array{Float64, 4}, false},
                         Tuple{}},
                 Tuple{Base.Slice{Base.OneTo{Int64}}, Int64, Int64}, true}, false}, Tuple{}}})
static(1)
```

This also changes `dense_dims(::ReshapedArray)` to return all falses when we know that the parent array isn't dense.