### PR TITLE
Fix `to_index` for `CartesianIndices` and `first` for `LazyAxis`

### DIFF
--- a/lib/ArrayInterfaceOffsetArrays/test/runtests.jl
+++ b/lib/ArrayInterfaceOffsetArrays/test/runtests.jl
@@ -11,6 +11,9 @@ Op = PermutedDimsArray(O,(3,1,2));
 @test @inferred(ArrayInterface.offsets(O)) === (4, 8, 11)
 @test @inferred(ArrayInterface.offsets(Op)) === (11, 4, 8)
 
+@test @inferred(ArrayInterface.to_indices(O, (:, :, :))) == (4:6, 8:11, 11:15)
+@test @inferred(ArrayInterface.to_indices(Op, (:, :, :))) == (11:15, 4:6, 8:11)
+
 @test @inferred(ArrayInterface.offsets((1,2,3))) === (StaticInt(1),)
 o = OffsetArray(vec(A), 8);
 @test @inferred(ArrayInterface.offset1(o)) === 9

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -220,7 +220,7 @@ ArrayInterfaceCore.known_first(::Type{<:LazyAxis{N,P}}) where {N,P} = known_offs
 ArrayInterfaceCore.known_first(::Type{<:LazyAxis{:,P}}) where {P} = 1
 @inline function Base.first(x::LazyAxis{N})::Int where {N}
     if ArrayInterfaceCore.known_first(x) === nothing
-        return Int(offsets(parent(x), StaticInt(N)))
+        return Int(offsets(getfield(x, :parent), StaticInt(N)))
     else
         return Int(known_first(x))
     end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -188,7 +188,7 @@ to_index(x, i::AbstractArray{Bool}) = LogicalIndex(i)
 to_index(x::LinearIndices, i::AbstractArray{Bool}) = LogicalIndex{Int}(i)
 # cartesian indexing
 @inline to_index(x, i::CartesianIndices{0}) = i
-@inline to_index(x, i::CartesianIndices) = axes(i)
+@inline to_index(x, i::CartesianIndices) = getfield(i, :indices)
 @inline to_index(x, i::CartesianIndex) = Tuple(i)
 @inline to_index(x, i::NDIndex) = Tuple(i)
 @inline to_index(x, i::AbstractArray{<:AbstractCartesianIndex}) = i

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -6,6 +6,7 @@
     @test @inferred(ArrayInterface.to_index(axis, CartesianIndex(1))) === (1,)
     @test @inferred(ArrayInterface.to_index(axis, 1:2)) === 1:2
     @test @inferred(ArrayInterface.to_index(axis, CartesianIndices((1:2,)))) == (1:2,)
+    @test @inferred(ArrayInterface.to_index(axis, CartesianIndices((2:3,)))) == (2:3,)
     @test @inferred(ArrayInterface.to_index(axis, [1, 2])) == [1, 2]
     @test @inferred(ArrayInterface.to_index(axis, [true, false, false])) == [1]
     index = @inferred(ArrayInterface.to_index(axis, :))


### PR DESCRIPTION
Fix #308, #309