### PR TITLE
Fix `getindex` with additional inds

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -254,7 +254,7 @@ end
 to_axes(A, a::Tuple, i::Tuple{<:CanonicalInt,Vararg{Any}}) = to_axes(A, tail(a), tail(i))
 to_axes(A, a::Tuple, i::Tuple{I,Vararg{Any}}) where {I} = _to_axes(StaticInt(ndims_index(I)), A, a, i)
 function _to_axes(::StaticInt{1}, A, axs::Tuple, inds::Tuple)
-    return (to_axis(first(axs), first(inds)), to_axes(A, tail(axs), tail(inds))...)
+    return (to_axis(_maybe_first(axs), first(inds)), to_axes(A, _maybe_tail(axs), tail(inds))...)
 end
 @propagate_inbounds function _to_axes(::StaticInt{N}, A, axs::Tuple, inds::Tuple) where {N}
     axes_front, axes_tail = Base.IteratorsMD.split(axs, Val(N))
@@ -267,6 +267,11 @@ end
 end
 to_axes(A, ::Tuple{Ax,Vararg{Any}}, ::Tuple{}) where {Ax} = ()
 to_axes(A, ::Tuple{}, ::Tuple{}) = ()
+
+_maybe_first(::Tuple{}) = static(1):static(1)
+_maybe_first(t::Tuple) = first(t)
+_maybe_tail(::Tuple{}) = ()
+_maybe_tail(t::Tuple) = tail(t)
 
 """
     to_axis(old_axis, index) -> new_axis

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -103,12 +103,34 @@ end
 @testset  "getindex with additional inds" begin
     A = reshape(1:12, (3, 4))
     subA = view(A, :, :)
+    LA = LinearIndices(A)
+    CA = CartesianIndices(A)
     @test @inferred(ArrayInterface.getindex(A, 1, 1, 1)) == 1
     @test @inferred(ArrayInterface.getindex(A, 1, 1, :)) == [1]
+    @test @inferred(ArrayInterface.getindex(A, 1, 1, 1:1)) == [1]
     @test @inferred(ArrayInterface.getindex(A, 1, 1, :, :)) == ones(1, 1)
+    @test @inferred(ArrayInterface.getindex(A, :, 1, 1)) == 1:3
+    @test @inferred(ArrayInterface.getindex(A, :, 1, :)) == reshape(1:3, 3, 1)
     @test @inferred(ArrayInterface.getindex(subA, 1, 1, 1)) == 1
     @test @inferred(ArrayInterface.getindex(subA, 1, 1, :)) == [1]
+    @test @inferred(ArrayInterface.getindex(subA, 1, 1, 1:1)) == [1]
     @test @inferred(ArrayInterface.getindex(subA, 1, 1, :, :)) == ones(1, 1)
+    @test @inferred(ArrayInterface.getindex(subA, :, 1, 1)) == 1:3
+    @test @inferred(ArrayInterface.getindex(subA, :, 1, :)) == reshape(1:3, 3, 1)
+    @test @inferred(ArrayInterface.getindex(LA, 1, 1, 1)) == 1
+    @test @inferred(ArrayInterface.getindex(LA, 1, 1, :)) == [1]
+    @test @inferred(ArrayInterface.getindex(LA, 1, 1, 1:1)) == [1]
+    @test @inferred(ArrayInterface.getindex(LA, 1, 1, :, :)) == ones(1, 1)
+    @test @inferred(ArrayInterface.getindex(LA, :, 1, 1)) == 1:3
+    @test @inferred(ArrayInterface.getindex(LA, :, 1, :)) == reshape(1:3, 3, 1)
+    @test @inferred(ArrayInterface.getindex(CA, 1, 1, 1)) == CartesianIndex(1, 1)
+    @test @inferred(ArrayInterface.getindex(CA, 1, 1, :)) == [CartesianIndex(1, 1)]
+    @test @inferred(ArrayInterface.getindex(CA, 1, 1, 1:1)) == [CartesianIndex(1, 1)]
+    @test @inferred(ArrayInterface.getindex(CA, 1, 1, :, :)) == fill(CartesianIndex(1, 1), 1, 1)
+    @test @inferred(ArrayInterface.getindex(CA, :, 1, 1)) ==
+        reshape(CartesianIndex(1, 1):CartesianIndex(3, 1), 3)
+    @test @inferred(ArrayInterface.getindex(CA, :, 1, :)) ==
+        reshape(CartesianIndex(1, 1):CartesianIndex(3, 1), 3, 1)
 end
 
 @testset "0-dimensional" begin

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -110,18 +110,24 @@ end
     @test @inferred(ArrayInterface.getindex(A, 1, 1, 1:1)) == [1]
     @test @inferred(ArrayInterface.getindex(A, 1, 1, :, :)) == ones(1, 1)
     @test @inferred(ArrayInterface.getindex(A, :, 1, 1)) == 1:3
+    @test @inferred(ArrayInterface.getindex(A, 2:3, 1, 1)) == 2:3
+    @test @inferred(ArrayInterface.getindex(A, static(1):2, 1, 1)) == 1:2
     @test @inferred(ArrayInterface.getindex(A, :, 1, :)) == reshape(1:3, 3, 1)
     @test @inferred(ArrayInterface.getindex(subA, 1, 1, 1)) == 1
     @test @inferred(ArrayInterface.getindex(subA, 1, 1, :)) == [1]
     @test @inferred(ArrayInterface.getindex(subA, 1, 1, 1:1)) == [1]
     @test @inferred(ArrayInterface.getindex(subA, 1, 1, :, :)) == ones(1, 1)
     @test @inferred(ArrayInterface.getindex(subA, :, 1, 1)) == 1:3
+    @test @inferred(ArrayInterface.getindex(subA, 2:3, 1, 1)) == 2:3
+    @test @inferred(ArrayInterface.getindex(subA, static(1):2, 1, 1)) == 1:2
     @test @inferred(ArrayInterface.getindex(subA, :, 1, :)) == reshape(1:3, 3, 1)
     @test @inferred(ArrayInterface.getindex(LA, 1, 1, 1)) == 1
     @test @inferred(ArrayInterface.getindex(LA, 1, 1, :)) == [1]
     @test @inferred(ArrayInterface.getindex(LA, 1, 1, 1:1)) == [1]
     @test @inferred(ArrayInterface.getindex(LA, 1, 1, :, :)) == ones(1, 1)
     @test @inferred(ArrayInterface.getindex(LA, :, 1, 1)) == 1:3
+    @test @inferred(ArrayInterface.getindex(LA, 2:3, 1, 1)) == 2:3
+    @test @inferred(ArrayInterface.getindex(LA, static(1):2, 1, 1)) == 1:2
     @test @inferred(ArrayInterface.getindex(LA, :, 1, :)) == reshape(1:3, 3, 1)
     @test @inferred(ArrayInterface.getindex(CA, 1, 1, 1)) == CartesianIndex(1, 1)
     @test @inferred(ArrayInterface.getindex(CA, 1, 1, :)) == [CartesianIndex(1, 1)]
@@ -129,6 +135,10 @@ end
     @test @inferred(ArrayInterface.getindex(CA, 1, 1, :, :)) == fill(CartesianIndex(1, 1), 1, 1)
     @test @inferred(ArrayInterface.getindex(CA, :, 1, 1)) ==
         reshape(CartesianIndex(1, 1):CartesianIndex(3, 1), 3)
+    @test @inferred(ArrayInterface.getindex(CA, 2:3, 1, 1)) ==
+        reshape(CartesianIndex(2, 1):CartesianIndex(3, 1), 2)
+    @test @inferred(ArrayInterface.getindex(CA, static(1):2, 1, 1)) ==
+        reshape(CartesianIndex(1, 1):CartesianIndex(2, 1), 2)
     @test @inferred(ArrayInterface.getindex(CA, :, 1, :)) ==
         reshape(CartesianIndex(1, 1):CartesianIndex(3, 1), 3, 1)
 end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -96,6 +96,19 @@ end
 
     @test ArrayInterface.to_axis(axis, axis) === axis
     @test ArrayInterface.to_axis(axis, ArrayInterface.indices(axis)) === axis
+
+    @test @inferred(ArrayInterface.to_axes(A, (), (inds,))) === (inds,)
+end
+
+@testset  "getindex with additional inds" begin
+    A = reshape(1:12, (3, 4))
+    subA = view(A, :, :)
+    @test @inferred(ArrayInterface.getindex(A, 1, 1, 1)) == 1
+    @test @inferred(ArrayInterface.getindex(A, 1, 1, :)) == [1]
+    @test @inferred(ArrayInterface.getindex(A, 1, 1, :, :)) == ones(1, 1)
+    @test @inferred(ArrayInterface.getindex(subA, 1, 1, 1)) == 1
+    @test @inferred(ArrayInterface.getindex(subA, 1, 1, :)) == [1]
+    @test @inferred(ArrayInterface.getindex(subA, 1, 1, :, :)) == ones(1, 1)
 end
 
 @testset "0-dimensional" begin


### PR DESCRIPTION
Cuurently, `getindex(A, inds...)` with `inds` whose length is larger than `ndims(A)` will cause a error, but it is allowed for `Base.getindex`:
```julia
julia> A = reshape(1:12, 3, 4)
3×4 reshape(::UnitRange{Int64}, 3, 4) with eltype Int64:
 1  4  7  10
 2  5  8  11
 3  6  9  12

julia> ArrayInterface.getindex(A, 1, 1, :)
ERROR: ArgumentError: tuple must be non-empty

julia> A[1, 1, :]
1-element Vector{Int64}:
 1
```

The reason is `to_axes` only works `length(inds) == ndims(A)` currently,
This PR fixes it with `_maybe_first` and `_maybe_tail`.

However, the behavior for `CartesianIndices` is different, which works currently but ignores additional inds
```julia
julia> ArrayInterface.getindex(CartesianIndices(A), 1, 1, :)
0-dimensional Array{CartesianIndex{2}, 0}:
CartesianIndex(1, 1)

julia> ArrayInterface.getindex(CartesianIndices(A), 1, 1, :, :)
0-dimensional Array{CartesianIndex{2}, 0}:
CartesianIndex(1, 1)

julia> ArrayInterface.getindex(CartesianIndices(A), 1, :, :, :)
4-element Vector{CartesianIndex{2}}:
 CartesianIndex(1, 1)
 CartesianIndex(1, 2)
 CartesianIndex(1, 3)
 CartesianIndex(1, 4)

julia> CartesianIndices(A)[1, :, :, :]
4×1×1 Array{CartesianIndex{2}, 3}:
[:, :, 1] =
 CartesianIndex(1, 1)
 CartesianIndex(1, 2)
 CartesianIndex(1, 3)
 CartesianIndex(1, 4)
```
How can I fix it or ignore it?