### PR TITLE
Expand the downstream tests for DiffEqSensitivity

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,7 +22,11 @@ jobs:
           - {user: SciML, repo: DiffEqBase.jl, group: Core}
           - {user: SciML, repo: DiffEqBase.jl, group: Downstream}
           - {user: SciML, repo: DiffEqBase.jl, group: Downstream2}
-          - {user: SciML, repo: DiffEqSensitivity.jl, group: Core}
+          - {user: SciML, repo: DiffEqSensitivity.jl, group: Core1}
+          - {user: SciML, repo: DiffEqSensitivity.jl, group: Core2}
+          - {user: SciML, repo: DiffEqSensitivity.jl, group: Core3}
+          - {user: SciML, repo: DiffEqSensitivity.jl, group: Core4}
+          - {user: SciML, repo: DiffEqSensitivity.jl, group: Core5}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Core}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface}
           - {user: SciML, repo: DelayDiffEq.jl, group: Interface}


### PR DESCRIPTION
As described in https://github.com/JuliaArrays/ArrayInterface.jl/pull/305#issuecomment-1153149047, these tests are probably the most reliant on abstract interfaces being correct, and so they would catch some of these details that the current downstream tests are missing, like the interface break caused by #305