### PR TITLE
`IndicesInfo` for succinct gathering of info on indices.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.16"
+version = "6.0.17"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -576,9 +576,8 @@ IndicesInfo(@nospecialize x::Tuple) = IndicesInfo(typeof(x))
         push!(NS.args, :(ndims_shape($(T_i))))
         push!(IS.args, :(is_splat_index($(T_i))))
     end
-    :(IndicesInfo{$(NI),$(NS),$(IS)}())
+    Expr(:block, Expr(:meta, :inline), :(IndicesInfo{$(NI),$(NS),$(IS)}()))
 end
-
 
 """
     instances_do_not_alias(::Type{T}) -> Bool

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -557,6 +557,13 @@ ndims_shape(@nospecialize T::Type{<:Number}) = 0
 ndims_shape(@nospecialize T::Type{<:AbstractArray}) = ndims(T)
 ndims_shape(x) = ndims_shape(typeof(x))
 
+"""
+    IndicesInfo(T::Type{<:Tuple}) -> IndicesInfo{NI,NS,IS}()
+
+Provides basic trait information for each index type in in the tuple `T`. `NI`, `NS`, and
+`IS` are tuples of [`ndims_index`](@ref), [`ndims_shape`](@ref), and
+[`is_splat_index`](@ref) (respectively) for each field of `T`.
+"""
 struct IndicesInfo{NI,NS,IS} end
 IndicesInfo(@nospecialize x::Tuple) = IndicesInfo(typeof(x))
 @generated function IndicesInfo(::Type{T}) where {T<:Tuple}

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -5,11 +5,6 @@ using LinearAlgebra: AbstractTriangular
 using SparseArrays
 using SuiteSparse
 
-@static if isdefined(Base, :ReshapedReinterpretArray)
-    _is_reshaped(::Type{<:Base.ReshapedReinterpretArray}) = true
-end
-_is_reshaped(::Type{<:Base.ReinterpretArray}) = false
-
 @static if isdefined(Base, Symbol("@assume_effects"))
     using Base: @assume_effects
 else

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -562,6 +562,22 @@ ndims_shape(@nospecialize T::Type{<:Number}) = 0
 ndims_shape(@nospecialize T::Type{<:AbstractArray}) = ndims(T)
 ndims_shape(x) = ndims_shape(typeof(x))
 
+struct IndicesInfo{NI,NS,IS} end
+IndicesInfo(@nospecialize x::Tuple) = IndicesInfo(typeof(x))
+@generated function IndicesInfo(::Type{T}) where {T<:Tuple}
+    NI = Expr(:tuple)
+    NS = Expr(:tuple)
+    IS = Expr(:tuple)
+    for i in 1:fieldcount(T)
+        T_i = fieldtype(T, i)
+        push!(NI.args, :(ndims_index($(T_i))))
+        push!(NS.args, :(ndims_shape($(T_i))))
+        push!(IS.args, :(is_splat_index($(T_i))))
+    end
+    :(IndicesInfo{$(NI),$(NS),$(IS)}())
+end
+
+
 """
     instances_do_not_alias(::Type{T}) -> Bool
 

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -4,8 +4,8 @@ using ArrayInterfaceCore
 import ArrayInterfaceCore: allowed_getindex, allowed_setindex!, aos_to_soa, buffer,
     parent_type, fast_matrix_colors, findstructralnz, has_sparsestruct,
     issingular, isstructured, matrix_colors, restructure, lu_instance,
-    safevec, zeromatrix, ColoringAlgorithm,
-    fast_scalar_indexing, parameterless_type, ndims_index, is_splat_index, is_forwarding_wrapper
+    safevec, zeromatrix, ColoringAlgorithm, fast_scalar_indexing, parameterless_type,
+    ndims_index, ndims_shape, is_splat_index, is_forwarding_wrapper, IndicesInfo
 
 # ArrayIndex subtypes and methods
 import ArrayInterfaceCore: ArrayIndex, MatrixIndex, VectorIndex, BidiagonalIndex, TridiagonalIndex


### PR DESCRIPTION
This tidies up the index traits into a single call, `IndicesInfo` and helps avoid directly indexing the `parameters` field within the generated method of `to_indices` (since access to that field directly is discouraged).