### PR TITLE
Improve performance of recent function-index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.17"
+version = "6.0.18"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -242,16 +242,16 @@ to_index(x::LinearIndices, i::AbstractArray{Bool}) = LogicalIndex{Int}(i)
 @inline to_index(x, i::NDIndex) = Tuple(i)
 @inline to_index(x, i::AbstractArray{<:AbstractCartesianIndex}) = i
 @inline function to_index(x, i::Base.Fix2{<:Union{typeof(<),typeof(isless)},<:Union{Base.BitInteger,StaticInt}})
-    offset1(x):min(_sub1(canonicalize(i.x)), static_lastindex(x))
+    static_first(x):min(_sub1(canonicalize(i.x)), static_last(x))
 end
 @inline function to_index(x, i::Base.Fix2{typeof(<=),<:Union{Base.BitInteger,StaticInt}})
-    offset1(x):min(canonicalize(i.x), static_lastindex(x))
+    static_first(x):min(canonicalize(i.x), static_last(x))
 end
 @inline function to_index(x, i::Base.Fix2{typeof(>=),<:Union{Base.BitInteger,StaticInt}})
-    max(canonicalize(i.x), offset1(x)):static_lastindex(x)
+    max(canonicalize(i.x), static_first(x)):static_last(x)
 end
 @inline function to_index(x, i::Base.Fix2{typeof(>),<:Union{Base.BitInteger,StaticInt}})
-    max(_add1(canonicalize(i.x)), offset1(x)):static_lastindex(x)
+    max(_add1(canonicalize(i.x)), static_first(x)):static_last(x)
 end
 # integer indexing
 to_index(x, i::AbstractArray{<:Integer}) = i


### PR DESCRIPTION
Previous versions were trying to use `firstindex` and `lastindex` to reference an axis but `first(axis)` and `last(axis)` is what we actually want and is faster.