### PR TITLE
Fixed buffer indexing type, `GetIndex`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.18"
+version = "6.0.19"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"


### PR DESCRIPTION
`getindex` is unique from other functions because macros are a critical part of it's design (`@propagate_inbounds`, `@inbounds`). `GetIndex` carries the bounds-checking information with the buffer, which can't be replicated using any combination of the other function composing types (`Splat`, `ComposedFunction`, etc.).