### PR TITLE
`IndexInfo` and `map_tuple_type`

### DIFF
--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -645,6 +645,7 @@ Provides basic trait information for each index type in in the tuple `T`. `NI`, 
 [`is_splat_index`](@ref) (respectively) for each field of `T`.
 """
 struct IndicesInfo{NI,NS,IS} end
+
 IndicesInfo(@nospecialize x::Tuple) = IndicesInfo(typeof(x))
 @generated function IndicesInfo(::Type{T}) where {T<:Tuple}
     NI = Expr(:tuple)
@@ -657,6 +658,10 @@ IndicesInfo(@nospecialize x::Tuple) = IndicesInfo(typeof(x))
         push!(IS.args, :(is_splat_index($(T_i))))
     end
     Expr(:block, Expr(:meta, :inline), :(IndicesInfo{$(NI),$(NS),$(IS)}()))
+end
+
+@inline function Base.getindex(::IndicesInfo{NI,NS,IS}, i::Int) where {NI,NS,IS}
+    IndexInfo{getfield(NI, i),getfield(NS, i),getfield(IS, i)}()
 end
 
 """


### PR DESCRIPTION
`IndexInfo` is the single dimension/argument version of `IndicesInfo` and `map_tuple_type` provides an optionally generated function so the compiler can optimize as necessary.