### PR TITLE
Create ArrayInterfaceStaticArraysCore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - ArrayInterfaceCUDA
           - ArrayInterfaceOffsetArrays
           - ArrayInterfaceStaticArrays
+          - ArrayInterfaceStaticArraysCore
           - ArrayInterfaceTracker
         version:
           - '1'

--- a/lib/ArrayInterfaceStaticArrays/Project.toml
+++ b/lib/ArrayInterfaceStaticArrays/Project.toml
@@ -1,10 +1,11 @@
 name = "ArrayInterfaceStaticArrays"
 uuid = "b0d46f97-bff5-4637-a19a-dd75974142cd"
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+ArrayInterfaceStaticArraysCore = "dd5226c6-a4d4-4bc7-8575-46859f9c95b9"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/lib/ArrayInterfaceStaticArrays/Project.toml
+++ b/lib/ArrayInterfaceStaticArrays/Project.toml
@@ -13,6 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 Adapt = "3"
 ArrayInterface = "6"
+ArrayInterfaceStaticArraysCore = "0.1"
 Static = "0.7"
 StaticArrays = "1.2.5, 1.3, 1.4"
 julia = "1.6"

--- a/lib/ArrayInterfaceStaticArrays/src/ArrayInterfaceStaticArrays.jl
+++ b/lib/ArrayInterfaceStaticArrays/src/ArrayInterfaceStaticArrays.jl
@@ -5,28 +5,9 @@ using ArrayInterface
 using LinearAlgebra
 using StaticArrays
 using Static
+import ArrayInterfaceStaticArraysCore
 
 const CanonicalInt = Union{Int,StaticInt}
-
-ArrayInterface.ismutable(::Type{<:StaticArrays.StaticArray}) = false
-ArrayInterface.ismutable(::Type{<:StaticArrays.MArray}) = true
-ArrayInterface.ismutable(::Type{<:StaticArrays.SizedArray}) = true
-
-ArrayInterface.can_setindex(::Type{<:StaticArrays.StaticArray}) = false
-ArrayInterface.buffer(A::Union{StaticArrays.SArray,StaticArrays.MArray}) = getfield(A, :data)
-
-function ArrayInterface.lu_instance(_A::StaticArrays.StaticMatrix{N,N}) where {N}
-    A = StaticArrays.SArray(_A)
-    L = LowerTriangular(A)
-    U = UpperTriangular(A)
-    p = StaticArrays.SVector{N,Int}(1:N)
-    return StaticArrays.LU(L, U, p)
-end
-
-function ArrayInterface.restructure(x::StaticArrays.SArray, y::StaticArrays.SArray)
-    reshape(y, StaticArrays.Size(x))
-end
-ArrayInterface.restructure(x::StaticArrays.SArray{S}, y) where {S} = StaticArrays.SArray{S}(y)
 
 ArrayInterface.known_first(::Type{<:StaticArrays.SOneTo}) = 1
 ArrayInterface.known_last(::Type{StaticArrays.SOneTo{N}}) where {N} = N
@@ -75,7 +56,5 @@ if StaticArrays.SizedArray{Tuple{8,8},Float64,2,2} isa UnionAll
 else
     ArrayInterface.parent_type(::Type{<:StaticArrays.SizedArray{S,T,M,N}}) where {S,T,M,N} = Array{T,N}
 end
-
-Adapt.adapt_storage(::Type{<:StaticArrays.SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
 
 end # module

--- a/lib/ArrayInterfaceStaticArrays/test/runtests.jl
+++ b/lib/ArrayInterfaceStaticArrays/test/runtests.jl
@@ -6,21 +6,10 @@ using Static
 using Test
 
 x = @SVector [1,2,3]
-@test ArrayInterface.ismutable(x) == false
-@test ArrayInterface.ismutable(view(x, 1:2)) == false
-@test ArrayInterface.can_setindex(typeof(x)) == false
-@test ArrayInterface.buffer(x) == x.data
 @test @inferred(ArrayInterface.device(typeof(x))) === ArrayInterface.CPUTuple()
 
 x = @MVector [1,2,3]
-@test ArrayInterface.ismutable(x) == true
-@test ArrayInterface.ismutable(view(x, 1:2)) == true
 @test @inferred(ArrayInterface.device(typeof(x))) === ArrayInterface.CPUPointer()
-
-A = @SMatrix(randn(5, 5))
-@test ArrayInterface.lu_instance(A) isa typeof(lu(A))
-A = @MMatrix(randn(5, 5))
-@test ArrayInterface.lu_instance(A) isa typeof(lu(A))
 
 @test isone(ArrayInterface.known_first(typeof(StaticArrays.SOneTo(7))))
 @test ArrayInterface.known_last(typeof(StaticArrays.SOneTo(7))) == 7
@@ -39,18 +28,6 @@ T = SizedArray{Tuple{5,4,3}}(zeros(5,4,3));
 @test @inferred(ArrayInterface.length(v)) === StaticInt(8)
 @test @inferred(ArrayInterface.length(A)) === StaticInt(42)
 @test @inferred(ArrayInterface.length(T)) === StaticInt(60)
-
-x = @SMatrix rand(Float32, 2, 2)
-y = @SVector rand(4)
-yr = ArrayInterface.restructure(x, y)
-@test yr isa SMatrix{2, 2}
-@test Base.size(yr) == (2,2)
-@test vec(yr) == vec(y)
-z = rand(4)
-zr = ArrayInterface.restructure(x, z)
-@test zr isa SMatrix{2, 2}
-@test Base.size(zr) == (2,2)
-@test vec(zr) == vec(z)
 
 Am = @MMatrix rand(2,10);
 @test @inferred(ArrayInterface.strides(view(Am,1,:))) === (StaticInt(2),)

--- a/lib/ArrayInterfaceStaticArraysCore/LICENSE
+++ b/lib/ArrayInterfaceStaticArraysCore/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 SciML
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/ArrayInterfaceStaticArraysCore/Project.toml
+++ b/lib/ArrayInterfaceStaticArraysCore/Project.toml
@@ -1,0 +1,21 @@
+name = "ArrayInterfaceStaticArraysCore"
+uuid = "dd5226c6-a4d4-4bc7-8575-46859f9c95b9"
+version = "0.1.0"
+
+[deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+
+[compat]
+Adapt = "3"
+ArrayInterfaceCore = "0.1.13"
+julia = "1.6"
+
+[extras]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["StaticArrays", "Test"]

--- a/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
@@ -15,7 +15,7 @@ function ArrayInterfaceCore.lu_instance(_A::StaticArraysCore.StaticMatrix{N,N}) 
 end
 
 function ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S,T,N}, y::StaticArraysCore.SArray) where {S,T,N}
-    reshape(y, StaticArraysCore.size_to_tuple(S))
+    StaticArraysCore.SArray{S,T,N}(y)
 end
 ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S}, y) where {S} = StaticArraysCore.SArray{S}(y)
 

--- a/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
@@ -1,0 +1,24 @@
+module ArrayInterfaceStaticArraysCore
+
+import StaticArraysCore, ArrayInterfaceCore
+using LinearAlgebra
+
+ArrayInterfaceCore.ismutable(::Type{<:StaticArraysCore.StaticArray}) = false
+ArrayInterfaceCore.ismutable(::Type{<:StaticArraysCore.MArray}) = true
+ArrayInterfaceCore.ismutable(::Type{<:StaticArraysCore.SizedArray}) = true
+
+ArrayInterfaceCore.can_setindex(::Type{<:StaticArraysCore.StaticArray}) = false
+ArrayInterfaceCore.buffer(A::Union{StaticArraysCore.SArray,StaticArraysCore.MArray}) = getfield(A, :data)
+
+function ArrayInterfaceCore.lu_instance(_A::StaticArraysCore.StaticMatrix{N,N}) where {N}
+    lu(one(_A))
+end
+
+function ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S,T,N}, y::StaticArraysCore.SArray) where {S,T,N}
+    reshape(y, StaticArraysCore.size_to_tuple(S))
+end
+ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S}, y) where {S} = StaticArraysCore.SArray{S}(y)
+
+Adapt.adapt_storage(::Type{<:StaticArrays.SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
+
+end

--- a/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
@@ -1,6 +1,6 @@
 module ArrayInterfaceStaticArraysCore
 
-import StaticArraysCore, ArrayInterfaceCore
+import StaticArraysCore, ArrayInterfaceCore, Adapt
 using LinearAlgebra
 
 ArrayInterfaceCore.ismutable(::Type{<:StaticArraysCore.StaticArray}) = false
@@ -19,6 +19,6 @@ function ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S,T,N}, y::St
 end
 ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S}, y) where {S} = StaticArraysCore.SArray{S}(y)
 
-Adapt.adapt_storage(::Type{<:StaticArrays.SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
+Adapt.adapt_storage(::Type{<:StaticArraysCore.SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
 
 end

--- a/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
@@ -1,0 +1,28 @@
+using StaticArrays, ArrayInterfaceCore, ArrayInterfaceStaticArraysCore, Test
+
+x = @SVector [1,2,3]
+@test ArrayInterface.ismutable(x) == false
+@test ArrayInterface.ismutable(view(x, 1:2)) == false
+@test ArrayInterface.can_setindex(typeof(x)) == false
+@test ArrayInterface.buffer(x) == x.data
+
+x = @MVector [1,2,3]
+@test ArrayInterface.ismutable(x) == true
+@test ArrayInterface.ismutable(view(x, 1:2)) == true
+
+A = @SMatrix(randn(5, 5))
+@test ArrayInterface.lu_instance(A) isa typeof(lu(A))
+A = @MMatrix(randn(5, 5))
+@test ArrayInterface.lu_instance(A) isa typeof(lu(A))
+
+x = @SMatrix rand(Float32, 2, 2)
+y = @SVector rand(4)
+yr = ArrayInterface.restructure(x, y)
+@test yr isa SMatrix{2, 2}
+@test Base.size(yr) == (2,2)
+@test vec(yr) == vec(y)
+z = rand(4)
+zr = ArrayInterface.restructure(x, z)
+@test zr isa SMatrix{2, 2}
+@test Base.size(zr) == (2,2)
+@test vec(zr) == vec(z)

--- a/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
@@ -1,4 +1,5 @@
 using StaticArrays, ArrayInterfaceCore, ArrayInterfaceStaticArraysCore, Test
+using LinearAlgebra
 
 x = @SVector [1,2,3]
 @test ArrayInterfaceCore.ismutable(x) == false

--- a/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
@@ -21,7 +21,7 @@ y = @SVector rand(4)
 yr = ArrayInterfaceCore.restructure(x, y)
 @test yr isa SMatrix{2, 2}
 @test Base.size(yr) == (2,2)
-@test vec(yr) == vec(y)
+@test vec(yr) == vec(Float32.(y))
 z = rand(4)
 zr = ArrayInterfaceCore.restructure(x, z)
 @test zr isa SMatrix{2, 2}

--- a/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/test/runtests.jl
@@ -1,28 +1,28 @@
 using StaticArrays, ArrayInterfaceCore, ArrayInterfaceStaticArraysCore, Test
 
 x = @SVector [1,2,3]
-@test ArrayInterface.ismutable(x) == false
-@test ArrayInterface.ismutable(view(x, 1:2)) == false
-@test ArrayInterface.can_setindex(typeof(x)) == false
-@test ArrayInterface.buffer(x) == x.data
+@test ArrayInterfaceCore.ismutable(x) == false
+@test ArrayInterfaceCore.ismutable(view(x, 1:2)) == false
+@test ArrayInterfaceCore.can_setindex(typeof(x)) == false
+@test ArrayInterfaceCore.buffer(x) == x.data
 
 x = @MVector [1,2,3]
-@test ArrayInterface.ismutable(x) == true
-@test ArrayInterface.ismutable(view(x, 1:2)) == true
+@test ArrayInterfaceCore.ismutable(x) == true
+@test ArrayInterfaceCore.ismutable(view(x, 1:2)) == true
 
 A = @SMatrix(randn(5, 5))
-@test ArrayInterface.lu_instance(A) isa typeof(lu(A))
+@test ArrayInterfaceCore.lu_instance(A) isa typeof(lu(A))
 A = @MMatrix(randn(5, 5))
-@test ArrayInterface.lu_instance(A) isa typeof(lu(A))
+@test ArrayInterfaceCore.lu_instance(A) isa typeof(lu(A))
 
 x = @SMatrix rand(Float32, 2, 2)
 y = @SVector rand(4)
-yr = ArrayInterface.restructure(x, y)
+yr = ArrayInterfaceCore.restructure(x, y)
 @test yr isa SMatrix{2, 2}
 @test Base.size(yr) == (2,2)
 @test vec(yr) == vec(y)
 z = rand(4)
-zr = ArrayInterface.restructure(x, z)
+zr = ArrayInterfaceCore.restructure(x, z)
 @test zr isa SMatrix{2, 2}
 @test Base.size(zr) == (2,2)
 @test vec(zr) == vec(z)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ end
 
 groups = if GROUP == "All"
     ["ArrayInterfaceCore", "ArrayInterface", "ArrayInterfaceBandedMatrices", "ArrayInterfaceBlockBandedMatrices",
-     "ArrayInterfaceOffsetArrays", "ArrayInterfaceStaticArrays",]
+     "ArrayInterfaceOffsetArrays", "ArrayInterfaceStaticArrays", "ArrayInterfaceStaticArraysCore"]
 else
     [GROUP]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,10 @@ if GROUP == "ArrayInterfaceBlockBandedMatrices"
     dev_subpkg("ArrayInterfaceBandedMatrices")
 end
 
+if GROUP == "ArrayInterfaceStaticArrays"
+    dev_subpkg("ArrayInterfaceStaticArraysCore")
+end
+
 groups = if GROUP == "All"
     ["ArrayInterfaceCore", "ArrayInterface", "ArrayInterfaceBandedMatrices", "ArrayInterfaceBlockBandedMatrices",
      "ArrayInterfaceOffsetArrays", "ArrayInterfaceStaticArrays",]


### PR DESCRIPTION
Now that there's StaticArraysCore, to have minimal dependencies I created ArrayInterfaceStaticArraysCore which only requires ArrayInterfaceCore and StaticArraysCore and implements all of the possible functions given those constraints (i.e. no static-ness), which covers all of the functions which are actually used by SciML downstream packages. Thus this will have a massive effect on downstream load times. As a result, a patch bump to ArrayInterfaceStaticArrays is done which just includes the core version so it's non-breaking. 