### PR TITLE
Make `stride_rank` public and document

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -83,6 +83,7 @@ ArrayInterface.offset1
 ArrayInterface.offsets
 ArrayInterface.setindex!
 ArrayInterface.size
+ArrayInterface.stride_rank
 ArrayInterface.strides
 ArrayInterface.to_axes
 ArrayInterface.to_axis

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -226,7 +226,8 @@ end
 """
     stride_rank(T::Type[, dim])
 
-Returns a tuple of the stride rank for each dimensioon for the multidimensional collection `T`.
+Returns a tuple of the stride rank for each dimensioon for the multidimensional collection
+`T` relative to its raw data.
 """
 stride_rank(x, dim) = getfield(stride_rank(x), dim)
 stride_rank(x) = stride_rank(typeof(x))

--- a/src/stridelayout.jl
+++ b/src/stridelayout.jl
@@ -222,8 +222,15 @@ function rank_to_sortperm(R::Tuple{Vararg{StaticInt,N}}) where {N}
     return sp
 end
 
-stride_rank(::Type{<:StrideIndex{N,R}}) where {N,R} = static(R)
+
+"""
+    stride_rank(T::Type[, dim])
+
+Returns a tuple of the stride rank for each dimensioon for the multidimensional collection `T`.
+"""
+stride_rank(x, dim) = getfield(stride_rank(x), dim)
 stride_rank(x) = stride_rank(typeof(x))
+stride_rank(::Type{<:StrideIndex{N,R}}) where {N,R} = static(R)
 function stride_rank(::Type{T}) where {T}
     is_forwarding_wrapper(T) ? stride_rank(parent_type(T)) : nothing
 end
@@ -249,8 +256,6 @@ function stride_rank(@nospecialize T::Type{<:SubArray})
         return map(GetIndex{false}(rank), to_parent_dims(T))
     end
 end
-
-stride_rank(x, i) = stride_rank(x)[i]
 function stride_rank(::Type{R}) where {T,N,S,A<:Array{S},R<:Base.ReinterpretArray{T,N,S,A}}
     return ntuple(static, StaticInt(N))
 end
@@ -285,7 +290,6 @@ end
     end
     :(Zero())
 end
-
 function stride_rank(::Type{Base.ReshapedArray{T, N, P, Tuple{Vararg{Base.SignedMultiplicativeInverse{Int},M}}}}) where {T,N,P,M}
     _reshaped_striderank(is_column_major(P), Val{N}(), Val{M}())
 end


### PR DESCRIPTION
We have the tooling to in place to solve #332. I think JuliaSIMD uses `stride_rank` too. So I figured it would make sense to just make this a public function and document it. @chriselrod, I'm pretty sure you were the original author on this so if there's something else to add to the documentation that would be welcomed.