### PR TITLE
Fix and update a bunch of docs along with the missing SetIndex! method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.20"
+version = "6.0.21"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,9 +10,13 @@ ArrayInterfaceCore.can_change_size
 ArrayInterfaceCore.can_setindex
 ArrayInterfaceCore.fast_matrix_colors
 ArrayInterfaceCore.fast_scalar_indexing
+ArrayInterfaceCore.is_forwarding_wrapper
 ArrayInterfaceCore.ismutable
 ArrayInterfaceCore.isstructured
 ArrayInterfaceCore.has_sparsestruct
+ArrayInterfaceCore.ndims_index
+ArrayInterfaceCore.ndims_shape
+
 ```
 
 ### Functions
@@ -36,6 +40,8 @@ ArrayInterfaceCore.zeromatrix
 
 ```@docs
 ArrayInterfaceCore.ArrayIndex
+ArrayInterfaceCore.GetIndex
+ArrayInterfaceCore.SetIndex!
 ```
 
 ## ArrayInterface.jl
@@ -63,7 +69,6 @@ ArrayInterface.known_offsets
 ArrayInterface.known_size
 ArrayInterface.known_step
 ArrayInterface.known_strides
-ArrayInterface.ndims_index
 ```
 
 ### Functions

--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.14"
+version = "0.1.15"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -6,7 +6,7 @@ import ArrayInterfaceCore: allowed_getindex, allowed_setindex!, aos_to_soa, buff
     issingular, isstructured, matrix_colors, restructure, lu_instance,
     safevec, zeromatrix, ColoringAlgorithm, fast_scalar_indexing, parameterless_type,
     ndims_index, ndims_shape, is_splat_index, is_forwarding_wrapper, IndicesInfo,
-    map_tuple_type, flatten_tuples, GetIndex
+    map_tuple_type, flatten_tuples, GetIndex, SetIndex!
 
 # ArrayIndex subtypes and methods
 import ArrayInterfaceCore: ArrayIndex, MatrixIndex, VectorIndex, BidiagonalIndex, TridiagonalIndex


### PR DESCRIPTION
Was implementing `SetIndex` and realized a bunch of docs were missing from the api.md file. Also cleaned up a bunch of my existing docs and added examples.