### PR TITLE
Add promote_eltype primitive to ArrayInterfaceCore

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,6 +33,7 @@ ArrayInterfaceCore.lu_instance
 ArrayInterfaceCore.matrix_colors
 ArrayInterfaceCore.issingular
 ArrayInterfaceCore.parent_type
+ArrayInterfaceCore.promote_eltype
 ArrayInterfaceCore.restructure
 ArrayInterfaceCore.safevec
 ArrayInterfaceCore.zeromatrix

--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.18"
+version = "0.1.19"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -132,6 +132,17 @@ parent_type(::Type{Diagonal{T,V}}) where {T,V} = V
 parent_type(T::Type) = T
 
 """
+    promote_eltype(::Type{<:AbstractArray{T,N}}, ::Type{T2})
+
+Computes the type of the `AbstractArray` that results from the element
+type changing to `promote_type(T,T2)`.
+
+Note that no generic fallback is given.
+"""
+function promote_eltype end
+promote_eltype(::Type{Array{T,N}}, ::Type{T2}) where {T,T2,N} = Array{promote_type(T,T2),N}
+
+"""
     buffer(x)
 
 Return the buffer data that `x` points to. Unlike `parent(x::AbstractArray)`, `buffer(x)`


### PR DESCRIPTION
The description is pretty self-explanatory. I found that this is a generally missing part of the interface which is required in order to compute types generated when doing type promotions on the element types of arrays. 