### PR TITLE
Overload `Base.to_index` (instead of using our own)

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -29,7 +29,7 @@ using IfElse
 
 using Base.Cartesian
 using Base: @propagate_inbounds, tail, OneTo, LogicalIndex, Slice, ReinterpretArray,
-    ReshapedArray, AbstractCartesianIndex
+    ReshapedArray, AbstractCartesianIndex, to_index
 
 using Base.Iterators: Pairs
 using LinearAlgebra

--- a/src/array_index.jl
+++ b/src/array_index.jl
@@ -35,3 +35,88 @@ end
     return Expr(:block, Expr(:meta, :inline), out)
 end
 
+struct AxisIndex{I,P,N} <: ArrayIndex{N}
+    index::I
+    parentdims::P
+
+    AxisIndex(@nospecialize(i), @nospecialize(d)) = new{typeof(i),typeof(d),ndims_index(i)}(i, d)
+    AxisIndex(@nospecialize(i::AxisIndex), @nospecialize(d)) = AxisIndex(getfield(i, :index), d)
+    AxisIndex(@nospecialize(i)) = AxisIndex(i, nothing)
+end
+
+parentdims(@nospecialize i::AxisIndex) = getfield(i, :parentdims)
+
+struct Begin <: ArrayIndex{1} end
+
+struct End <: ArrayIndex{1} end
+
+ndims_index(@nospecialize T::Type{<:AxisIndex}) = ndims_index(fieldtype(T, :index))
+ndims_index(::Type{Begin}) = 1
+ndims_index(::Type{End}) = 1
+
+ndims_shape(@nospecialize T::Type{<:AxisIndex}) = ndims_shape(fieldtype(T, :index))
+ndims_shape(::Type{Begin}) = 0
+ndims_shape(::Type{End}) = 0
+
+Base.:(:)(::Begin, stop) = AxisIndex(<=(stop))
+Base.:(:)(start, ::End) = AxisIndex(>=(start))
+Base.:(:)(::Begin, ::End) = (:)
+
+is_splat_index(@nospecialize T::Type{<:AxisIndex}) = is_splat_index(fieldtype(T, :index))
+
+to_indices(A, ::Tuple{}) = ()
+@inline to_indices(A, inds::Tuple{Vararg{Any}}) = Base.to_indices(A, as_indices(A, inds))
+
+Base.to_index(A, @nospecialize(i::AxisIndex{<:Union{CartesianIndices{0,Tuple{}},Base.Slice,StaticInt,AbstractArray{<:Integer},AbstractArray{<:AbstractCartesianIndex}}})) = getfield(i, :index)
+# FIXME better tracking of trailing dimensions
+@inline function as_indices(::A, inds::I) where {A,I}
+    minfo = map_indices_info(IndicesInfo{ndims(A)}(I))
+    ntuple(Val{nfields(minfo)}()) do i
+        pdim = getfield(getfield(minfo, i), 2)
+        if pdim === StaticInt(0)
+            AxisIndex(getfield(inds, i), StaticInt(ndims(A) + 1))
+        else
+            AxisIndex(getfield(inds, i), pdim)
+        end
+    end
+end
+@inline function Base.to_indices(A, inds::Tuple{Vararg{ArrayIndex}})
+    Base.to_indices(A, as_indices(A, inds))
+end
+@inline function Base.to_indices(A, inds::Tuple{Vararg{AxisIndex{<:Any,<:Union{StaticInt,Tuple,Colon}}}})
+    flatten_tuples(map(Fix1(Base.to_index, A), inds))
+end
+
+@inline Base.to_index(A, i::AxisIndex{Colon}) = indices(lazy_axes(A, parentdims(i)))
+@inline function Base.to_index(A, @nospecialize(i::AxisIndex{<:Union{CartesianIndex,NDIndex,CartesianIndices}}))
+    getfield(getfield(i, :index), 1)
+end
+@inline Base.to_index(A, i::AxisIndex{<:Base.BitInteger}) = Int(getfield(i, :index))
+@inline function Base.to_index(A, i::AxisIndex{<:AbstractArray{Bool}})
+    if (last(parentdims(i)) == ndims(A)) && (IndexStyle(A) isa IndexLinear)
+        return LogicalIndex{Int}(getfield(i, :index))
+    else
+        return LogicalIndex(getfield(i, :index))
+    end
+end
+@inline Base.to_index(A, i::AxisIndex{Begin}) = static_first(lazy_axes(A, parentdims(i)))
+@inline Base.to_index(A, i::AxisIndex{End}) = static_last(lazy_axes(A, parentdims(i)))
+@inline function Base.to_index(A, i::AxisIndex{<:Fix2{<:Union{typeof(<),typeof(isless)},<:Union{Base.BitInteger,StaticInt}}})
+    x = lazy_axes(A, parentdims(i))
+    static_first(x):min(_sub1(canonicalize(getfield(i, :index).x)), static_last(x))
+end
+@inline function Base.to_index(A, i::AxisIndex{<:Fix2{typeof(<=),<:Union{Base.BitInteger,StaticInt}}})
+    x = lazy_axes(A, parentdims(i))
+    static_first(x):min(canonicalize(getfield(i, :index).x), static_last(x))
+end
+@inline function Base.to_index(A, i::AxisIndex{<:Fix2{typeof(>=),<:Union{Base.BitInteger,StaticInt}}})
+    x = lazy_axes(A, parentdims(i))
+    max(canonicalize(getfield(i, :index).x), static_first(x)):static_last(x)
+end
+@inline function Base.to_index(A, i::AxisIndex{<:Fix2{typeof(>),<:Union{Base.BitInteger,StaticInt}}})
+    x = lazy_axes(A, getfield(i, :parentdims))
+    max(_add1(canonicalize(getfield(i, :index).x)), static_first(x)):static_last(x)
+end
+@inline function Base.to_index(A, i::AxisIndex)
+    to_index(CartesianIndices(lazy_axes(A, parentdims(i))), getfield(i, :index))
+end

--- a/src/array_index.jl
+++ b/src/array_index.jl
@@ -20,8 +20,9 @@ struct StrideIndex{N,R,C,S,O} <: ArrayIndex{N}
 end
 
 ## getindex
-@propagate_inbounds Base.getindex(x::ArrayIndex, i::CanonicalInt, ii::CanonicalInt...) = x[NDIndex(i, ii...)]
-
+@propagate_inbounds function Base.getindex(x::ArrayIndex, i::CanonicalInt, ii::CanonicalInt...)
+    x[NDIndex(i, ii...)]
+end
 @inline function Base.getindex(x::StrideIndex{N}, i::AbstractCartesianIndex) where {N}
     return _strides2int(offsets(x), strides(x), Tuple(i)) + static(1)
 end
@@ -37,38 +38,16 @@ end
 
 struct AxisIndex{I,P,N} <: ArrayIndex{N}
     index::I
-    parentdims::P
+    pdims::P
 
     AxisIndex(@nospecialize(i), @nospecialize(d)) = new{typeof(i),typeof(d),ndims_index(i)}(i, d)
     AxisIndex(@nospecialize(i::AxisIndex), @nospecialize(d)) = AxisIndex(getfield(i, :index), d)
     AxisIndex(@nospecialize(i)) = AxisIndex(i, nothing)
 end
 
-parentdims(@nospecialize i::AxisIndex) = getfield(i, :parentdims)
-
-struct Begin <: ArrayIndex{1} end
-
-struct End <: ArrayIndex{1} end
-
 ndims_index(@nospecialize T::Type{<:AxisIndex}) = ndims_index(fieldtype(T, :index))
-ndims_index(::Type{Begin}) = 1
-ndims_index(::Type{End}) = 1
-
 ndims_shape(@nospecialize T::Type{<:AxisIndex}) = ndims_shape(fieldtype(T, :index))
-ndims_shape(::Type{Begin}) = 0
-ndims_shape(::Type{End}) = 0
-
-Base.:(:)(::Begin, stop) = AxisIndex(<=(stop))
-Base.:(:)(start, ::End) = AxisIndex(>=(start))
-Base.:(:)(::Begin, ::End) = (:)
-
 is_splat_index(@nospecialize T::Type{<:AxisIndex}) = is_splat_index(fieldtype(T, :index))
-
-to_indices(A, ::Tuple{}) = ()
-@inline to_indices(A, inds::Tuple{Vararg{Any}}) = Base.to_indices(A, as_indices(A, inds))
-
-Base.to_index(A, @nospecialize(i::AxisIndex{<:Union{CartesianIndices{0,Tuple{}},Base.Slice,StaticInt,AbstractArray{<:Integer},AbstractArray{<:AbstractCartesianIndex}}})) = getfield(i, :index)
-# FIXME better tracking of trailing dimensions
 @inline function as_indices(::A, inds::I) where {A,I}
     minfo = map_indices_info(IndicesInfo{ndims(A)}(I))
     ntuple(Val{nfields(minfo)}()) do i
@@ -79,44 +58,4 @@ Base.to_index(A, @nospecialize(i::AxisIndex{<:Union{CartesianIndices{0,Tuple{}},
             AxisIndex(getfield(inds, i), pdim)
         end
     end
-end
-@inline function Base.to_indices(A, inds::Tuple{Vararg{ArrayIndex}})
-    Base.to_indices(A, as_indices(A, inds))
-end
-@inline function Base.to_indices(A, inds::Tuple{Vararg{AxisIndex{<:Any,<:Union{StaticInt,Tuple,Colon}}}})
-    flatten_tuples(map(Fix1(Base.to_index, A), inds))
-end
-
-@inline Base.to_index(A, i::AxisIndex{Colon}) = indices(lazy_axes(A, parentdims(i)))
-@inline function Base.to_index(A, @nospecialize(i::AxisIndex{<:Union{CartesianIndex,NDIndex,CartesianIndices}}))
-    getfield(getfield(i, :index), 1)
-end
-@inline Base.to_index(A, i::AxisIndex{<:Base.BitInteger}) = Int(getfield(i, :index))
-@inline function Base.to_index(A, i::AxisIndex{<:AbstractArray{Bool}})
-    if (last(parentdims(i)) == ndims(A)) && (IndexStyle(A) isa IndexLinear)
-        return LogicalIndex{Int}(getfield(i, :index))
-    else
-        return LogicalIndex(getfield(i, :index))
-    end
-end
-@inline Base.to_index(A, i::AxisIndex{Begin}) = static_first(lazy_axes(A, parentdims(i)))
-@inline Base.to_index(A, i::AxisIndex{End}) = static_last(lazy_axes(A, parentdims(i)))
-@inline function Base.to_index(A, i::AxisIndex{<:Fix2{<:Union{typeof(<),typeof(isless)},<:Union{Base.BitInteger,StaticInt}}})
-    x = lazy_axes(A, parentdims(i))
-    static_first(x):min(_sub1(canonicalize(getfield(i, :index).x)), static_last(x))
-end
-@inline function Base.to_index(A, i::AxisIndex{<:Fix2{typeof(<=),<:Union{Base.BitInteger,StaticInt}}})
-    x = lazy_axes(A, parentdims(i))
-    static_first(x):min(canonicalize(getfield(i, :index).x), static_last(x))
-end
-@inline function Base.to_index(A, i::AxisIndex{<:Fix2{typeof(>=),<:Union{Base.BitInteger,StaticInt}}})
-    x = lazy_axes(A, parentdims(i))
-    max(canonicalize(getfield(i, :index).x), static_first(x)):static_last(x)
-end
-@inline function Base.to_index(A, i::AxisIndex{<:Fix2{typeof(>),<:Union{Base.BitInteger,StaticInt}}})
-    x = lazy_axes(A, getfield(i, :parentdims))
-    max(_add1(canonicalize(getfield(i, :index).x)), static_first(x)):static_last(x)
-end
-@inline function Base.to_index(A, i::AxisIndex)
-    to_index(CartesianIndices(lazy_axes(A, parentdims(i))), getfield(i, :index))
 end

--- a/src/axes.jl
+++ b/src/axes.jl
@@ -119,6 +119,7 @@ axes(A::VecAdjTrans) = (SOneTo{1}(), axes(parent(A), 1))
 @inline _sub_axes(x::SubArray, axis::SOneTo) = axis
 _sub_axes(x::SubArray, ::StaticInt{index}) where {index} = axes(getfield(x.indices, index))
 
+axes(A, ::Colon) = indices(A)
 @inline axes(A, dim) = _axes(A, to_dims(A, dim))
 @inline _axes(A, dim::Int) = dim > ndims(A) ? OneTo(1) : getfield(axes(A), dim)
 @inline function _axes(A, ::StaticInt{dim}) where {dim}

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,21 +1,4 @@
 
-@testset "to_index" begin
-    axis = 1:3
-    @test @inferred(ArrayInterface.to_index(axis, 1)) === 1
-    @test @inferred(ArrayInterface.to_index(axis, static(1))) === static(1)
-    @test @inferred(ArrayInterface.to_index(axis, CartesianIndex(1))) === (1,)
-    @test @inferred(ArrayInterface.to_index(axis, 1:2)) === 1:2
-    @test @inferred(ArrayInterface.to_index(axis, CartesianIndices((1:2,)))) == (1:2,)
-    @test @inferred(ArrayInterface.to_index(axis, CartesianIndices((2:3,)))) == (2:3,)
-    @test @inferred(ArrayInterface.to_index(axis, [1, 2])) == [1, 2]
-    @test @inferred(ArrayInterface.to_index(axis, [true, false, false])) == [1]
-    index = @inferred(ArrayInterface.to_index(axis, :))
-    @test @inferred(ArrayInterface.to_index(axis, index)) == index == ArrayInterface.indices(axis)
-
-    x = LinearIndices((static(0):static(3), static(3):static(5), static(-2):static(0)))
-    @test_throws ArgumentError ArrayInterface.to_index(axis, error)
-end
-
 @testset "unsafe_reconstruct" begin
     one_to = Base.OneTo(10)
     opt_ur = StaticInt(1):10
@@ -50,7 +33,6 @@ end
     @test @inferred(ArrayInterface.to_indices(ones(2, 2, 2), ([true, true], CartesianIndex(1, 1)))) == ([1, 2], 1, 1)
     @test @inferred(ArrayInterface.to_indices(a, (1, 1))) == (1, 1)
     @test @inferred(ArrayInterface.to_indices(a, (1, CartesianIndex(1)))) == (1, 1)
-    @test @inferred(ArrayInterface.to_indices(a, (1, false))) == (1, 0)
     @test @inferred(ArrayInterface.to_indices(a, (1, 1:2))) == (1, 1:2)
     @test @inferred(ArrayInterface.to_indices(a, (1:2, 1))) == (1:2, 1)
     @test @inferred(ArrayInterface.to_indices(a, (1, :))) == (1, Base.Slice(1:2))


### PR DESCRIPTION
Initial effort to get rid of our own internal definitions of `ArrayInterface.to_index` using new `AxisIndex` type for overloading with any array type (e.g., `Base.to_index(::Any, ::AxisIndex)`. `AxisIndex` contains all the information to retrieve the appropriate axes for a give index passed through `to_indices`. This also lets us dispatch on `Base.to_indices(A, ::Tuple{Vararg{<:ArrayIndex}})` now, so we are pretty close to eliminating the need for any unique methods on our part here. This implementation also doesn't cause any additional invalidations.

Initial benchmarks seemed to be good but I'm trying to balance excess method specialization with performance, which is likely to be highly dependent on Julia versions.