### PR TITLE
 Fixing lu_instance doesnt work on julia-1.8 

### DIFF
--- a/lib/ArrayInterfaceCUDA/Project.toml
+++ b/lib/ArrayInterfaceCUDA/Project.toml
@@ -7,6 +7,7 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 ArrayInterfaceGPUArrays = "6ba088a2-8465-4c0a-af30-387133b534db"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 Adapt = "3"
@@ -14,4 +15,3 @@ ArrayInterface = "5, 6"
 ArrayInterfaceGPUArrays = "0.1"
 CUDA = "3.9"
 julia = "1.6"
-

--- a/lib/ArrayInterfaceCUDA/src/ArrayInterfaceCUDA.jl
+++ b/lib/ArrayInterfaceCUDA/src/ArrayInterfaceCUDA.jl
@@ -4,8 +4,14 @@ using Adapt
 using ArrayInterface, ArrayInterfaceGPUArrays
 using CUDA
 
+using LinearAlgebra
+
 function ArrayInterface.lu_instance(A::CuMatrix{T}) where {T}
-    CUDA.CUSOLVER.CuQR(similar(A, 0, 0), similar(A, 0))
+    if VERSION >= v"1.8-0"
+        LinearAlgebra.qr!(A)
+    else
+        CUDA.CUSOLVER.CuQR(similar(A, 0, 0), similar(A, 0))
+    end
 end
 
 ArrayInterface.device(::Type{<:CUDA.CuArray}) = ArrayInterface.GPU()

--- a/lib/ArrayInterfaceCUDA/test/runtests.jl
+++ b/lib/ArrayInterfaceCUDA/test/runtests.jl
@@ -1,1 +1,4 @@
-using ArrayInterfaceCUDA
+using ArrayInterfaceCUDA, CUDA, Test
+
+A = cu(rand(4,4))
+@test ArrayInterface.lu_instance(A) isa CUDA.CUSOLVER.CuQR


### PR DESCRIPTION
With the new release of Julia 1.8 the public interface of CUDA.CUSOLVER changed.
This requires that the implementation of the lu_instance function has to change.