### PR TITLE
Trait methods for `allunique` and `issorted`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "6.0.23"
+version = "6.0.24"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"

--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.20"
+version = "0.1.21"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -736,58 +736,58 @@ known_step(T::Type) = is_forwarding_wrapper(T) ? known_step(parent_type(T)) : no
 known_step(@nospecialize T::Type{<:AbstractUnitRange}) = 1
 
 """
-    known_allunique(T::Type) -> Bool
+    is_set_like(T::Type) -> Bool
 
-Returns `true` if instances of `T` enforce all values to be unique.
+Returns `true` if collections of type `T` are always composed of a unique set of elements.
+This does not require that `T` subtypes `AbstractSet` or implements the `AbstractSet`
+interface.
 
 # Examples
 
 ```julia
-julia> ArrayInterfaceCore.known_allunique(BitSet())
+julia> ArrayInterfaceCore.is_set_like(BitSet())
 true
 
-julia> ArrayInterfaceCore.known_allunique([])
+julia> ArrayInterfaceCore.is_set_like([])
 false
 
-julia> ArrayInterfaceCore.known_allunique(typeof(1:10))
+julia> ArrayInterfaceCore.is_set_like(typeof(1:10))
 true
 
-julia> ArrayInterfaceCore.known_allunique(LinRange(1, 1, 10))
+julia> ArrayInterfaceCore.is_set_like(LinRange(1, 1, 10))
 false
 
 ```
 """
-known_allunique(@nospecialize T::Type{<:Union{AbstractSet,AbstractDict}}) = true
-known_allunique(T::Type{<:LinRange}) = false
-known_allunique(@nospecialize T::Type{<:AbstractRange}) = true
-function known_allunique(T::Type)
-    is_forwarding_wrapper(T) ? known_allunique(parent_type(T)) : false
-end
-known_allunique(@nospecialize(x)) = known_allunique(typeof(x))
+is_set_like(@nospecialize T::Type{<:Union{AbstractSet,AbstractDict}}) = true
+is_set_like(@nospecialize T::Type{<:LinRange}) = false
+is_set_like(@nospecialize T::Type{<:AbstractRange}) = true
+is_set_like(T::Type) = is_forwarding_wrapper(T) ? is_set_like(parent_type(T)) : false
+is_set_like(@nospecialize(x)) = is_set_like(typeof(x))
 
 """
-    known_issorted(T::Type) -> Bool
+    ensures_sorted(T::Type) -> Bool
 
 Returns `true` if all instances of `T` are sorted.
 
 # Examples
 
 ```julia
-julia> ArrayInterfaceCore.known_issorted(BitSet())
+julia> ArrayInterfaceCore.ensures_sorted(BitSet())
 true
 
-julia> ArrayInterfaceCore.known_issorted([])
+julia> ArrayInterfaceCore.ensures_sorted([])
 false
 
-julia> ArrayInterfaceCore.known_issorted(1:10)
+julia> ArrayInterfaceCore.ensures_sorted(1:10)
 true
 
 ```
 """
-known_issorted(@nospecialize(T::Type{BitSet})) = true
-known_issorted(@nospecialize( T::Type{<:AbstractRange})) = known_step(T) === 1
-known_issorted(T::Type) = is_forwarding_wrapper(T) ? known_issorted(parent_type(T)) : false
-known_issorted(@nospecialize(x)) = known_issorted(typeof(x))
+ensures_sorted(@nospecialize(T::Type{BitSet})) = true
+ensures_sorted(@nospecialize( T::Type{<:AbstractRange})) = known_step(T) === 1
+ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(T)) : false
+ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
 
 """
     is_splat_index(::Type{T}) -> Bool

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -540,6 +540,8 @@ struct CheckParent end
 struct CPUIndex <: AbstractCPU end
 struct GPU <: AbstractDevice end
 
+
+
 """
     device(::Type{T}) -> AbstractDevice
 
@@ -732,6 +734,60 @@ julia> ArrayInterface.known_step(typeof(1:4))
 known_step(x) = known_step(typeof(x))
 known_step(T::Type) = is_forwarding_wrapper(T) ? known_step(parent_type(T)) : nothing
 known_step(@nospecialize T::Type{<:AbstractUnitRange}) = 1
+
+"""
+    known_allunique(T::Type) -> Bool
+
+Returns `true` if instances of `T` enforce all values to be unique.
+
+# Examples
+
+```julia
+julia> ArrayInterfaceCore.known_allunique(BitSet())
+true
+
+julia> ArrayInterfaceCore.known_allunique([])
+false
+
+julia> ArrayInterfaceCore.known_allunique(typeof(1:10))
+true
+
+julia> ArrayInterfaceCore.known_allunique(LinRange(1, 1, 10))
+false
+
+```
+"""
+known_allunique(@nospecialize T::Type{<:Union{AbstractSet,AbstractDict}}) = true
+known_allunique(T::Type{<:LinRange}) = false
+known_allunique(@nospecialize T::Type{<:AbstractRange}) = true
+function known_allunique(T::Type)
+    is_forwarding_wrapper(T) ? known_allunique(parent_type(T)) : false
+end
+known_allunique(@nospecialize(x)) = known_allunique(typeof(x))
+
+"""
+    known_issorted(T::Type) -> Bool
+
+Returns `true` if all instances of `T` are sorted.
+
+# Examples
+
+```julia
+julia> ArrayInterfaceCore.known_issorted(BitSet())
+true
+
+julia> ArrayInterfaceCore.known_issorted([])
+false
+
+julia> ArrayInterfaceCore.known_issorted(1:10)
+true
+
+```
+"""
+known_issorted(@nospecialize(T::Type{BitSet})) = true
+known_issorted(@nospecialize( T::Type{<:AbstractRange})) = known_step(T) === 1
+known_issorted(T::Type) = is_forwarding_wrapper(T) ? known_issorted(parent_type(T)) : false
+known_issorted(@nospecialize(x)) = known_issorted(typeof(x))
 
 """
     is_splat_index(::Type{T}) -> Bool

--- a/lib/ArrayInterfaceCore/test/runtests.jl
+++ b/lib/ArrayInterfaceCore/test/runtests.jl
@@ -241,17 +241,17 @@ end
     @test [STri[rowind[i],colind[i]] for i in 1:length(rowind)]==[1,2,3,4,5,6,7,5,6,7]
 end
 
-@testset "known_allunique" begin
-    @test ArrayInterfaceCore.known_allunique(BitSet())
-    @test !ArrayInterfaceCore.known_allunique([])
-    @test ArrayInterfaceCore.known_allunique(1:10)
-    @test !ArrayInterfaceCore.known_allunique(LinRange(1, 1, 10))
+@testset "is_set_like" begin
+    @test ArrayInterfaceCore.is_set_like(BitSet())
+    @test !ArrayInterfaceCore.is_set_like([])
+    @test ArrayInterfaceCore.is_set_like(1:10)
+    @test !ArrayInterfaceCore.is_set_like(LinRange(1, 1, 10))
 end
 
-@testset "known_issorted" begin
-    @test ArrayInterfaceCore.known_issorted(BitSet())
-    @test !ArrayInterfaceCore.known_issorted([])
-    @test ArrayInterfaceCore.known_issorted(1:10)
+@testset "ensures_sorted" begin
+    @test ArrayInterfaceCore.ensures_sorted(BitSet())
+    @test !ArrayInterfaceCore.ensures_sorted([])
+    @test ArrayInterfaceCore.ensures_sorted(1:10)
 end
 
 @testset "known values" begin

--- a/lib/ArrayInterfaceCore/test/runtests.jl
+++ b/lib/ArrayInterfaceCore/test/runtests.jl
@@ -241,6 +241,19 @@ end
     @test [STri[rowind[i],colind[i]] for i in 1:length(rowind)]==[1,2,3,4,5,6,7,5,6,7]
 end
 
+@testset "known_allunique" begin
+    @test ArrayInterfaceCore.known_allunique(BitSet())
+    @test !ArrayInterfaceCore.known_allunique([])
+    @test ArrayInterfaceCore.known_allunique(1:10)
+    @test !ArrayInterfaceCore.known_allunique(LinRange(1, 1, 10))
+end
+
+@testset "known_issorted" begin
+    @test ArrayInterfaceCore.known_issorted(BitSet())
+    @test !ArrayInterfaceCore.known_issorted([])
+    @test ArrayInterfaceCore.known_issorted(1:10)
+end
+
 @testset "known values" begin
     CI = CartesianIndices((2, 2))
 

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -7,7 +7,7 @@ import ArrayInterfaceCore: allowed_getindex, allowed_setindex!, aos_to_soa, buff
     safevec, zeromatrix, ColoringAlgorithm, fast_scalar_indexing, parameterless_type,
     ndims_index, ndims_shape, is_splat_index, is_forwarding_wrapper, IndicesInfo, childdims,
     parentdims, map_tuple_type, flatten_tuples, GetIndex, SetIndex!, defines_strides,
-    stride_preserving_index
+    stride_preserving_index, known_allunique, known_issorted
 
 # ArrayIndex subtypes and methods
 import ArrayInterfaceCore: ArrayIndex, MatrixIndex, VectorIndex, BidiagonalIndex, TridiagonalIndex

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -7,7 +7,7 @@ import ArrayInterfaceCore: allowed_getindex, allowed_setindex!, aos_to_soa, buff
     safevec, zeromatrix, ColoringAlgorithm, fast_scalar_indexing, parameterless_type,
     ndims_index, ndims_shape, is_splat_index, is_forwarding_wrapper, IndicesInfo, childdims,
     parentdims, map_tuple_type, flatten_tuples, GetIndex, SetIndex!, defines_strides,
-    stride_preserving_index, known_allunique, known_issorted
+    stride_preserving_index, is_set_like, ensures_sorted
 
 # ArrayIndex subtypes and methods
 import ArrayInterfaceCore: ArrayIndex, MatrixIndex, VectorIndex, BidiagonalIndex, TridiagonalIndex


### PR DESCRIPTION
In some cases, `allunique(::T)` and `issorted(::T)` will return `true` for all instances of `T`. In such cases `T` usually is overloaded for these and returns `true` with no operation, but in other cases this has to be checked at run time. This makes `issorted` and `allunique` poor methods for programmatic choices in code. For example, if we want to find a value we may end up iterating over the entire collection just to see if we can use `searchsortedfirst`.

This introduces trait method counterparts to `allunique` and `issorted` that only return `true` when this can be guaranteed from the type. ~~These are currently called `known_allunique` and `known_issorted` but I'm open to whatever syntax people prefer.~~

Changed the names to `is_set_like` and `ensures_sorted`.
