### PR TITLE
move `undefmatrix` overload to `ArrayInterfaceStaticarraysCore`

### DIFF
--- a/lib/ArrayInterfaceStaticArrays/src/ArrayInterfaceStaticArrays.jl
+++ b/lib/ArrayInterfaceStaticArrays/src/ArrayInterfaceStaticArrays.jl
@@ -9,14 +9,6 @@ import ArrayInterfaceStaticArraysCore
 
 const CanonicalInt = Union{Int,StaticInt}
 
-function ArrayInterface.undefmatrix(::MArray{S, T, N, L}) where {S, T, N, L}
-    return MMatrix{L, L, T, L*L}(undef)
-end
-# SArray doesn't have an undef constructor and is going to be small enough that this is fine.
-function ArrayInterface.undefmatrix(s::SArray)
-    v = vec(s)
-    return v.*v'
-end
 ArrayInterface.known_first(::Type{<:StaticArrays.SOneTo}) = 1
 ArrayInterface.known_last(::Type{StaticArrays.SOneTo{N}}) where {N} = N
 ArrayInterface.known_length(::Type{StaticArrays.SOneTo{N}}) where {N} = N

--- a/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
@@ -3,6 +3,15 @@ module ArrayInterfaceStaticArraysCore
 import StaticArraysCore, ArrayInterfaceCore, Adapt
 using LinearAlgebra
 
+function ArrayInterfaceCore.undefmatrix(::StaticArraysCore.MArray{S, T, N, L}) where {S, T, N, L}
+    return MMatrix{L, L, T, L*L}(undef)
+end
+# SArray doesn't have an undef constructor and is going to be small enough that this is fine.
+function ArrayInterfaceCore.undefmatrix(s::StaticArraysCore.SArray)
+    v = vec(s)
+    return v.*v'
+end
+
 ArrayInterfaceCore.ismutable(::Type{<:StaticArraysCore.StaticArray}) = false
 ArrayInterfaceCore.ismutable(::Type{<:StaticArraysCore.MArray}) = true
 ArrayInterfaceCore.ismutable(::Type{<:StaticArraysCore.SizedArray}) = true


### PR DESCRIPTION
As requested by @ChrisRackauckas.