### PR TITLE
Update Umfpack constructor for 1.9

### DIFF
--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -453,16 +453,22 @@ function lu_instance(A::Matrix{T}) where {T}
     return LU{luT}(similar(A, 0, 0), ipiv, info)
 end
 function lu_instance(jac_prototype::SparseMatrixCSC)
-    SuiteSparse.UMFPACK.UmfpackLU(
-        Ptr{Cvoid}(),
-        Ptr{Cvoid}(),
-        1,
-        1,
-        jac_prototype.colptr[1:1],
-        jac_prototype.rowval[1:1],
-        jac_prototype.nzval[1:1],
-        0,
-    )
+    @static if VERSION < v"1.9"
+        SuiteSparse.UMFPACK.UmfpackLU(
+            Ptr{Cvoid}(),
+            Ptr{Cvoid}(),
+            1,
+            1,
+            jac_prototype.colptr[1:1],
+            jac_prototype.rowval[1:1],
+            jac_prototype.nzval[1:1],
+            0,
+        )
+    else
+        SuiteSparse.UMFPACK.UmfpackLU(
+            similar(jac_prototype, 1, 1)
+        )
+    end
 end
 
 """

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -453,7 +453,7 @@ function lu_instance(A::Matrix{T}) where {T}
     return LU{luT}(similar(A, 0, 0), ipiv, info)
 end
 function lu_instance(jac_prototype::SparseMatrixCSC)
-    @static if VERSION < v"1.9"
+    @static if VERSION < v"1.9.0-DEV.1622"
         SuiteSparse.UMFPACK.UmfpackLU(
             Ptr{Cvoid}(),
             Ptr{Cvoid}(),


### PR DESCRIPTION
Peering too deep into the Umfpack internals makes it difficult for us to change them. Hopefully this constructor is sufficient for this use case? Fixes #356 