### PR TITLE
Fix `@assume_effects` compat

### DIFF
--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.23"
+version = "0.1.24"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -8,11 +8,16 @@ using SuiteSparse
 @static if isdefined(Base, Symbol("@assume_effects"))
     using Base: @assume_effects
 else
-    macro assume_effects(_, ex)
-        :(Base.@pure $(ex))
+    macro assume_effects(args...)
+        n = nfields(args)
+        call = getfield(args, call)
+        if n === 2 && getfield(args, 1) === QuoteNode(:total)
+            return esc(:(Base.@pure $(call)))
+        else
+            return call
+        end
     end
 end
-
 @assume_effects :total __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -14,7 +14,7 @@ else
         if n === 2 && getfield(args, 1) === QuoteNode(:total)
             return esc(:(Base.@pure $(call)))
         else
-            return call
+            return esc(call)
         end
     end
 end

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -10,7 +10,7 @@ using SuiteSparse
 else
     macro assume_effects(args...)
         n = nfields(args)
-        call = getfield(args, call)
+        call = getfield(args, n)
         if n === 2 && getfield(args, 1) === QuoteNode(:total)
             return esc(:(Base.@pure $(call)))
         else

--- a/lib/ArrayInterfaceCore/test/runtests.jl
+++ b/lib/ArrayInterfaceCore/test/runtests.jl
@@ -11,6 +11,12 @@ using Test
 using Aqua
 Aqua.test_all(ArrayInterfaceCore)
 
+# ensure we are correctly parsing these
+ArrayInterfaceCore.@assume_effects :total foo(x::Bool) = x
+ArrayInterfaceCore.@assume_effects bar(x::Bool) = x
+@test foo(true)
+@test bar(true)
+
 @testset "zeromatrix and unsafematrix" begin
     for T in (Int, Float32, Float64)
         for (vectype, mattype) in ((Vector{T}, Matrix{T}), (SparseVector{T}, SparseMatrixCSC{T, Int}))


### PR DESCRIPTION
Julia v1.6 doesn't have assumed effects so we have a fallback defined. However, the previous implementation doesn't have proper macro hygiene and assumes only `@assume_effects :total call` is ever done. This only provides the `@pure` def when applicable.