### PR TITLE
loosen AdjTrans definitions

### DIFF
--- a/lib/ArrayInterfaceCore/Project.toml
+++ b/lib/ArrayInterfaceCore/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterfaceCore"
 uuid = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-version = "0.1.26"
+version = "0.1.27"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -22,8 +22,8 @@ end
 parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)
 
-const VecAdjTrans{<:Any,V<:AbstractVector{T}} = Union{Transpose{T,V},Adjoint{T,V}}
-const MatAdjTrans{<:Any,M<:AbstractMatrix{T}} = Union{Transpose{T,M},Adjoint{T,M}}
+const VecAdjTrans{T,V<:AbstractVector{T}} = Union{Transpose{<:Any,V},Adjoint{<:Any,V}}
+const MatAdjTrans{T,M<:AbstractMatrix{T}} = Union{Transpose{<:Any,M},Adjoint{<:Any,M}}
 const UpTri{T,M} = Union{UpperTriangular{T,M},UnitUpperTriangular{T,M}}
 const LoTri{T,M} = Union{LowerTriangular{T,M},UnitLowerTriangular{T,M}}
 

--- a/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
+++ b/lib/ArrayInterfaceCore/src/ArrayInterfaceCore.jl
@@ -22,8 +22,8 @@ end
 parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)
 
-const VecAdjTrans{T,V<:AbstractVector{T}} = Union{Transpose{T,V},Adjoint{T,V}}
-const MatAdjTrans{T,M<:AbstractMatrix{T}} = Union{Transpose{T,M},Adjoint{T,M}}
+const VecAdjTrans{<:Any,V<:AbstractVector{T}} = Union{Transpose{T,V},Adjoint{T,V}}
+const MatAdjTrans{<:Any,M<:AbstractMatrix{T}} = Union{Transpose{T,M},Adjoint{T,M}}
 const UpTri{T,M} = Union{UpperTriangular{T,M},UnitUpperTriangular{T,M}}
 const LoTri{T,M} = Union{LowerTriangular{T,M},UnitLowerTriangular{T,M}}
 


### PR DESCRIPTION
The intention is to support
```julia
julia> ArrayInterface.stride_rank(typeof(td'))

julia> typeof(td')
Adjoint{Union{}, Matrix{TropicalF32}}
```
with this PR
```julia
julia> using ArrayInterface, TropicalNumbers

julia> d = rand(Float32, 4000, 4000); r = similar(d); td = Tropical.(d); tr = similar(td);

julia> ArrayInterface.stride_rank(typeof(td'))
(static(2), static(1))
```
