### PR TITLE
Fix GPUArrays extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ julia = "1.6"
 ArrayInterfaceBandedMatricesExt = "BandedMatrices"
 ArrayInterfaceBlockBandedMatricesExt = "BlockBandedMatrices"
 ArrayInterfaceCUDAExt = "CUDA"
-ArrayInterfaceGPUArraysExt = "GPUArraysCore"
+ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
 ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
 ArrayInterfaceTrackerExt = "Tracker"
 

--- a/ext/ArrayInterfaceGPUArraysCoreExt.jl
+++ b/ext/ArrayInterfaceGPUArraysCoreExt.jl
@@ -1,4 +1,4 @@
-module ArrayInterfaceGPUArraysExt
+module ArrayInterfaceGPUArraysCoreExt
 
 using Adapt
 using ArrayInterface


### PR DESCRIPTION
For me the GPUArrays extension errors on loading:

```julia
julia> using ArrayInterface, GPUArrays
┌ Error: Error during loading of extension ArrayInterfaceGPUArraysExt of ArrayInterface, use `Base.retry_load_extensions()` to retry.
└ @ Base loading.jl:1191

julia> Base.retry_load_extensions()
┌ Error: Error during loading of extension ArrayInterfaceGPUArraysExt of ArrayInterface, use `Base.retry_load_extensions()` to retry.
└ @ Base loading.jl:1191

(jl_IbDEwH) pkg> st
Status `/tmp/jl_IbDEwH/Project.toml`
  [4fba245c] ArrayInterface v7.0.0
  [0c68f7d7] GPUArrays v8.6.3

julia> versioninfo()
Julia Version 1.9.0-beta4
Commit b75ddb787ff (2023-02-07 21:53 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 8 × 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, tigerlake)
  Threads: 8 on 8 virtual cores
Environment:
  JULIA_CMDSTAN_HOME = /home/sethaxen/software/cmdstan/2.30.1/
  JULIA_NUM_THREADS = auto
  JULIA_EDITOR = code
```

This could be because the extension filename does not match the extension and module name. With this PR, the extension no longer fails to load for me.