### PR TITLE
Type level traits corresponding to `issorted` and `allunique`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,6 +32,8 @@ ArrayInterface.can_change_size
 ArrayInterface.can_setindex
 ArrayInterface.device
 ArrayInterface.defines_strides
+ArrayInterface.ensures_all_unique
+ArrayInterface.ensures_sorted
 ArrayInterface.fast_matrix_colors
 ArrayInterface.fast_scalar_indexing
 ArrayInterface.indices_do_not_alias

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -827,6 +827,60 @@ struct BandedMatrixIndex <: ArrayInterface.MatrixIndex
     isrow::Bool
 end
 
+"""
+    ensures_all_unique(T::Type) -> Bool
+
+Returns `true` if all instances of type `T` are composed of a unique set of elements.
+This does not require that `T` subtypes `AbstractSet` or implements the `AbstractSet`
+interface.
+
+# Examples
+
+```julia
+julia> ArrayInterface.ensures_all_unique(BitSet())
+true
+
+julia> ArrayInterface.ensures_all_unique([])
+false
+
+julia> ArrayInterface.ensures_all_unique(typeof(1:10))
+true
+
+julia> ArrayInterface.ensures_all_unique(LinRange(1, 1, 10))
+false
+```
+"""
+ensures_all_unique(@nospecialize T::Type{<:Union{AbstractSet,AbstractDict}}) = true
+ensures_all_unique(@nospecialize T::Type{<:LinRange}) = false
+ensures_all_unique(@nospecialize T::Type{<:AbstractRange}) = true
+@inline function ensures_all_unique(T::Type)
+    is_forwarding_wrapper(T) ? ensures_all_unique(parent_type(T)) : false
+end
+ensures_all_unique(@nospecialize(x)) = ensures_all_unique(typeof(x))
+
+"""
+    ensures_sorted(T::Type) -> Bool
+
+Returns `true` if all instances of `T` are sorted.
+
+# Examples
+
+```julia
+julia> ArrayInterface.ensures_sorted(BitSet())
+true
+
+julia> ArrayInterface.ensures_sorted([])
+false
+
+julia> ArrayInterface.ensures_sorted(1:10)
+true
+```
+"""
+ensures_sorted(@nospecialize(T::Type{BitSet})) = true
+ensures_sorted(@nospecialize( T::Type{<:AbstractRange})) = true
+ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(T)) : false
+ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
+
 ## Extensions
 
 import Requires

--- a/test/core.jl
+++ b/test/core.jl
@@ -246,3 +246,16 @@ end
   @test !ArrayInterface.indices_do_not_alias(typeof(view(fill(rand(4,4),4,4)', 2:3, 1:2)))
   @test !ArrayInterface.indices_do_not_alias(typeof(view(rand(4,4)', StepRangeLen(1,0,5), 1:2)))
 end
+
+@testset "ensures_all_unique" begin
+    @test ArrayInterface.ensures_all_unique(BitSet())
+    @test !ArrayInterface.ensures_all_unique([])
+    @test ArrayInterface.ensures_all_unique(1:10)
+    @test !ArrayInterface.ensures_all_unique(LinRange(1, 1, 10))
+end
+
+@testset "ensures_sorted" begin
+    @test ArrayInterface.ensures_sorted(BitSet())
+    @test !ArrayInterface.ensures_sorted([])
+    @test ArrayInterface.ensures_sorted(1:10)
+end


### PR DESCRIPTION
Refactor of #354.

`ensures_all_unique` and `ensures_sorted` are used to test for types that are always going to return `true` for `allunique` and `issorted`, respectively. This may be used to avoid checking each element at runtime.

Alternative names might be `all_unique_type` and `is_sorted_type`.