### PR TITLE
correct Requires usage to fix issues with PackageCompiler sysimages

### DIFF
--- a/ext/ArrayInterfaceBandedMatricesExt.jl
+++ b/ext/ArrayInterfaceBandedMatricesExt.jl
@@ -1,8 +1,16 @@
 module ArrayInterfaceBandedMatricesExt
 
-using ArrayInterface
-using ArrayInterface: BandedMatrixIndex
-isdefined(Base, :get_extension) ? (using BandedMatrices) : (using ..BandedMatrices)
+
+if isdefined(Base, :get_extension)
+    using ArrayInterface
+    using ArrayInterface: BandedMatrixIndex
+    using BandedMatrices
+else
+    using ..ArrayInterface
+    using ..ArrayInterface: BandedMatrixIndex
+    using ..BandedMatrices
+end
+
 
 Base.firstindex(i::BandedMatrixIndex) = 1
 Base.lastindex(i::BandedMatrixIndex) = i.count

--- a/ext/ArrayInterfaceBlockBandedMatricesExt.jl
+++ b/ext/ArrayInterfaceBlockBandedMatricesExt.jl
@@ -1,12 +1,15 @@
 module ArrayInterfaceBlockBandedMatricesExt
 
-using ArrayInterface
-using ArrayInterface: BandedMatrixIndex
 
-if isdefined(Base, :get_extension) 
+
+if isdefined(Base, :get_extension)
+    using ArrayInterface
+    using ArrayInterface: BandedMatrixIndex
     using BlockBandedMatrices
     using BlockBandedMatrices.BlockArrays
 else
+    using ..ArrayInterface
+    using ..ArrayInterface: BandedMatrixIndex
     using ..BlockBandedMatrices
     using ..BlockBandedMatrices.BlockArrays
 end

--- a/ext/ArrayInterfaceCUDAExt.jl
+++ b/ext/ArrayInterfaceCUDAExt.jl
@@ -2,15 +2,15 @@ module ArrayInterfaceCUDAExt
 
 using ArrayInterface
 
-if isdefined(Base, :get_extension) 
+if isdefined(Base, :get_extension)
     using CUDA
     using CUDA.CUSOLVER
-else 
+    using LinearAlgebra
+else
     using ..CUDA
     using ..CUDA.CUSOLVER
+    using ..LinearAlgebra
 end
-
-using LinearAlgebra
 
 function ArrayInterface.lu_instance(A::CuMatrix{T}) where {T}
     if VERSION >= v"1.8-"

--- a/ext/ArrayInterfaceGPUArraysCoreExt.jl
+++ b/ext/ArrayInterfaceGPUArraysCoreExt.jl
@@ -2,6 +2,7 @@ module ArrayInterfaceGPUArraysCoreExt
 
 
 if isdefined(Base, :get_extension)
+    using Adapt
     using ArrayInterface
     using LinearAlgebra: lu
     import GPUArraysCore

--- a/ext/ArrayInterfaceGPUArraysCoreExt.jl
+++ b/ext/ArrayInterfaceGPUArraysCoreExt.jl
@@ -1,9 +1,17 @@
 module ArrayInterfaceGPUArraysCoreExt
 
-using Adapt
-using ArrayInterface
-using LinearAlgebra: lu
-isdefined(Base, :get_extension) ? (import GPUArraysCore) : (import ..GPUArraysCore)
+
+if isdefined(Base, :get_extension)
+    using Adapt
+    using ArrayInterface
+    using LinearAlgebra: lu
+    import GPUArraysCore
+else
+    using ..Adapt
+    using ..ArrayInterface
+    using ..LinearAlgebra: lu
+    import ..GPUArraysCore
+end
 
 ArrayInterface.fast_scalar_indexing(::Type{<:GPUArraysCore.AbstractGPUArray}) = false
 @inline ArrayInterface.allowed_getindex(x::GPUArraysCore.AbstractGPUArray, i...) = GPUArraysCore.@allowscalar(x[i...])

--- a/ext/ArrayInterfaceGPUArraysCoreExt.jl
+++ b/ext/ArrayInterfaceGPUArraysCoreExt.jl
@@ -7,7 +7,7 @@ if isdefined(Base, :get_extension)
     using LinearAlgebra: lu
     import GPUArraysCore
 else
-    using ..Adapt
+    using Adapt # Will cause problems for relocatability.
     using ..ArrayInterface
     using ..LinearAlgebra: lu
     import ..GPUArraysCore

--- a/ext/ArrayInterfaceGPUArraysCoreExt.jl
+++ b/ext/ArrayInterfaceGPUArraysCoreExt.jl
@@ -2,7 +2,6 @@ module ArrayInterfaceGPUArraysCoreExt
 
 
 if isdefined(Base, :get_extension)
-    using Adapt
     using ArrayInterface
     using LinearAlgebra: lu
     import GPUArraysCore

--- a/ext/ArrayInterfaceStaticArraysCoreExt.jl
+++ b/ext/ArrayInterfaceStaticArraysCoreExt.jl
@@ -1,8 +1,14 @@
 module ArrayInterfaceStaticArraysCoreExt
 
-import ArrayInterface
-using LinearAlgebra
-isdefined(Base, :get_extension) ? (import StaticArraysCore) : (import ..StaticArraysCore)
+if isdefined(Base, :get_extension)
+    import ArrayInterface
+    using LinearAlgebra
+    import StaticArraysCore
+else
+    import ..ArrayInterface
+    using ..LinearAlgebra
+    import ..StaticArraysCore
+end
 
 function ArrayInterface.undefmatrix(::StaticArraysCore.MArray{S, T, N, L}) where {S, T, N, L}
     return StaticArraysCore.MMatrix{L, L, T, L*L}(undef)

--- a/ext/ArrayInterfaceTrackerExt.jl
+++ b/ext/ArrayInterfaceTrackerExt.jl
@@ -1,7 +1,12 @@
 module ArrayInterfaceTrackerExt
 
-using ArrayInterface
-isdefined(Base, :get_extension) ? (import Tracker) : (import ..Tracker)
+if isdefined(Base, :get_extension)
+    using ArrayInterface
+    import Tracker
+else
+    using ..ArrayInterface
+    import ..Tracker
+end
 
 ArrayInterface.ismutable(::Type{<:Tracker.TrackedArray}) = false
 ArrayInterface.ismutable(T::Type{<:Tracker.TrackedReal}) = false


### PR DESCRIPTION
Basically, the rule for Requires to work with sysimages is that it should load no package non-relatively. 