### PR TITLE
remove specialization of `Adapt.adapt_storage` for `StaticArraysCore.SArray`

### DIFF
--- a/lib/ArrayInterfaceStaticArraysCore/Project.toml
+++ b/lib/ArrayInterfaceStaticArraysCore/Project.toml
@@ -3,13 +3,11 @@ uuid = "dd5226c6-a4d4-4bc7-8575-46859f9c95b9"
 version = "0.1.3"
 
 [deps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
-Adapt = "3"
 ArrayInterfaceCore = "0.1.22"
 StaticArraysCore = "1"
 julia = "1.6"

--- a/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
+++ b/lib/ArrayInterfaceStaticArraysCore/src/ArrayInterfaceStaticArraysCore.jl
@@ -1,6 +1,6 @@
 module ArrayInterfaceStaticArraysCore
 
-import StaticArraysCore, ArrayInterfaceCore, Adapt
+import StaticArraysCore, ArrayInterfaceCore
 using LinearAlgebra
 
 function ArrayInterfaceCore.undefmatrix(::StaticArraysCore.MArray{S, T, N, L}) where {S, T, N, L}
@@ -27,7 +27,5 @@ function ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S,T,N}, y::St
     StaticArraysCore.SArray{S,T,N}(y)
 end
 ArrayInterfaceCore.restructure(x::StaticArraysCore.SArray{S}, y) where {S} = StaticArraysCore.SArray{S}(y)
-
-Adapt.adapt_storage(::Type{<:StaticArraysCore.SArray{S}}, xs::Array) where {S} = SArray{S}(xs)
 
 end


### PR DESCRIPTION
**Do not merge this as it is**

As suggested in #388 by @ChrisRackauckas, we should remove the specialization of `Adapt.adapt_storage` for `StaticArraysCore.SArray`s after adding the support upstream. As far as I know, we need a new branch - maybe `release-6` - for this and create a new release. I cannot create new branches in this repo, so I just prepared the required changes in this PR, starting from v6.0.25 as base.