### PR TITLE
Expertiment with fixing static array restructure method

### DIFF
--- a/ext/ArrayInterfaceStaticArraysCoreExt.jl
+++ b/ext/ArrayInterfaceStaticArraysCoreExt.jl
@@ -30,9 +30,6 @@ function ArrayInterface.lu_instance(_A::StaticArraysCore.StaticMatrix{N,N}) wher
     lu(one(_A))
 end
 
-function ArrayInterface.restructure(x::StaticArraysCore.SArray{S,T,N}, y::StaticArraysCore.SArray) where {S,T,N}
-    StaticArraysCore.SArray{S,T,N}(y)
-end
 ArrayInterface.restructure(x::StaticArraysCore.SArray{S}, y) where {S} = StaticArraysCore.SArray{S}(y)
 
 end

--- a/test/staticarrayscore.jl
+++ b/test/staticarrayscore.jl
@@ -22,7 +22,7 @@ y = @SVector rand(4)
 yr = ArrayInterface.restructure(x, y)
 @test yr isa SMatrix{2, 2}
 @test Base.size(yr) == (2,2)
-@test vec(yr) == vec(Float32.(y))
+@test vec(yr) == vec(y)
 z = rand(4)
 zr = ArrayInterface.restructure(x, z)
 @test zr isa SMatrix{2, 2}


### PR DESCRIPTION
The `restructure(x,y)` method for static arrays does not preserve the type of `y`, which is inconsistent with other methods of `restructure`. However, it may be that downstream packages rely on this behaviour. See #404, https://github.com/JuliaDiff/SparseDiffTools.jl/issues/237, https://github.com/JuliaArrays/ArrayInterface.jl/commit/691acbfcd0fa0175faa8f269730636b56dd24c99