### PR TITLE
Fix BigFloat QR instance and test better

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -576,6 +576,10 @@ function qr_instance(A::Matrix{T}) where {T}
     LinearAlgebra.QRCompactWYQ(zeros(T,0,0),zeros(T,0,0))
 end
 
+function qr_instance(A::Matrix{BigFloat})
+    LinearAlgebra.QR(zeros(BigFloat,0,0),zeros(BigFloat,0))
+end
+
 # Could be optimized but this should work for any real case.
 function qr_instance(jac_prototype::SparseMatrixCSC)
     qr(sparse(rand(1,1)))

--- a/test/core.jl
+++ b/test/core.jl
@@ -260,7 +260,7 @@ end
     @test ArrayInterface.ensures_sorted(1:10)
 end
 
-@testset "linearalgebra instances" being
+@testset "linearalgebra instances" begin
     for A in [rand(2,2), rand(Float32,2,2), rand(BigFloat,2,2)]
         @test ArrayInterface.bunchkaufman_instance(A) isa typeof(bunchkaufman(A' * A))
         @test ArrayInterface.cholesky_instance(A) isa typeof(cholesky(A' * A))

--- a/test/core.jl
+++ b/test/core.jl
@@ -262,11 +262,15 @@ end
 
 @testset "linearalgebra instances" begin
     for A in [rand(2,2), rand(Float32,2,2), rand(BigFloat,2,2)]
-        @test ArrayInterface.bunchkaufman_instance(A) isa typeof(bunchkaufman(A' * A))
-        @test ArrayInterface.cholesky_instance(A) isa typeof(cholesky(A' * A))
-        @test ArrayInterface.ldlt_instance(A) isa typeof(ldlt(SymTridiagonal(A' * A)))
+        
         @test ArrayInterface.lu_instance(A) isa typeof(lu(A))
         @test ArrayInterface.qr_instance(A) isa typeof(qr(A))
-        @test ArrayInterface.svd_instance(A) isa typeof(svd(A))
+
+        if !(eltype(A) isa BigFloat)
+            @test ArrayInterface.bunchkaufman_instance(A) isa typeof(bunchkaufman(A' * A))
+            @test ArrayInterface.cholesky_instance(A) isa typeof(cholesky(A' * A))
+            @test ArrayInterface.ldlt_instance(A) isa typeof(ldlt(SymTridiagonal(A' * A)))
+            @test ArrayInterface.svd_instance(A) isa typeof(svd(A))
+        end
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -266,7 +266,7 @@ end
         @test ArrayInterface.lu_instance(A) isa typeof(lu(A))
         @test ArrayInterface.qr_instance(A) isa typeof(qr(A))
 
-        if !(eltype(A) isa BigFloat)
+        if !(eltype(A) <: BigFloat)
             @test ArrayInterface.bunchkaufman_instance(A) isa typeof(bunchkaufman(A' * A))
             @test ArrayInterface.cholesky_instance(A) isa typeof(cholesky(A' * A))
             @test ArrayInterface.ldlt_instance(A) isa typeof(ldlt(SymTridiagonal(A' * A)))

--- a/test/core.jl
+++ b/test/core.jl
@@ -267,5 +267,6 @@ end
         @test ArrayInterface.ldlt_instance(A) isa typeof(ldlt(SymTridiagonal(A' * A)))
         @test ArrayInterface.lu_instance(A) isa typeof(lu(A))
         @test ArrayInterface.qr_instance(A) isa typeof(qr(A))
+        @test ArrayInterface.svd_instance(A) isa typeof(svd(A))
     end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -259,3 +259,13 @@ end
     @test !ArrayInterface.ensures_sorted([])
     @test ArrayInterface.ensures_sorted(1:10)
 end
+
+@testset "linearalgebra instances" being
+    for A in [rand(2,2), rand(Float32,2,2), rand(BigFloat,2,2)]
+        @test ArrayInterface.bunchkaufman_instance(A) isa typeof(bunchkaufman(A' * A))
+        @test ArrayInterface.cholesky_instance(A) isa typeof(cholesky(A' * A))
+        @test ArrayInterface.ldlt_instance(A) isa typeof(ldlt(SymTridiagonal(A' * A)))
+        @test ArrayInterface.lu_instance(A) isa typeof(lu(A))
+        @test ArrayInterface.qr_instance(A) isa typeof(qr(A))
+    end
+end


### PR DESCRIPTION
Found in https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/4527032588/jobs/8065045759#step:6:517 that there's a special case to consider here. Now it's better tested.