### PR TITLE
Better instance construction for ldlt

### DIFF
--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -546,11 +546,15 @@ Returns an instance of the LDLT factorization object with the correct type
 cheaply.
 """
 function ldlt_instance(A::Matrix{T}) where {T}  
-    return ldlt(SymTridiagonal(similar(A, 0, 0)))
+    return ldlt_instance(SymTridiagonal(similar(A, 0, 0)))
 end
 
 function ldlt_instance(A::SparseMatrixCSC)
     ldlt(sparse(similar(A, 1, 1)), check=false)
+end
+
+function ldlt_instance(A::SymTridiagonal{T,V}) where {T,V}
+    return LinearAlgebra.LDLt{T,SymTridiagonal{T,V}}(A)
 end
 
 """


### PR DESCRIPTION
Cannot be singular checked in some versions, so this is a nicer way to handle it.

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2041
