### PR TITLE
Fixed can_setindex for MArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ArrayInterface"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.7.0"
+version = "7.7.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/ArrayInterfaceStaticArraysCoreExt.jl
+++ b/ext/ArrayInterfaceStaticArraysCoreExt.jl
@@ -24,6 +24,7 @@ ArrayInterface.ismutable(::Type{<:StaticArraysCore.MArray}) = true
 ArrayInterface.ismutable(::Type{<:StaticArraysCore.SizedArray}) = true
 
 ArrayInterface.can_setindex(::Type{<:StaticArraysCore.StaticArray}) = false
+ArrayInterface.can_setindex(::Type{<:StaticArraysCore.MArray}) = true
 ArrayInterface.buffer(A::Union{StaticArraysCore.SArray,StaticArraysCore.MArray}) = getfield(A, :data)
 
 function ArrayInterface.lu_instance(_A::StaticArraysCore.StaticMatrix{N,N}) where {N}

--- a/test/staticarrayscore.jl
+++ b/test/staticarrayscore.jl
@@ -11,6 +11,7 @@ x = @SVector [1,2,3]
 x = @MVector [1,2,3]
 @test ArrayInterface.ismutable(x) == true
 @test ArrayInterface.ismutable(view(x, 1:2)) == true
+@test ArrayInterface.can_setindex(typeof(x)) == true
 
 A = @SMatrix(randn(5, 5))
 @test ArrayInterface.lu_instance(A) isa typeof(lu(A))


### PR DESCRIPTION
`can_setindex` now evaluates to `true` for `Type{<:StaticArraysCore.MArray}`.

See [Issue 428](https://github.com/JuliaArrays/ArrayInterface.jl/issues/428).

@Tokazama 