### PR TITLE
chore: add `has_trivial_array_constructor`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -52,6 +52,7 @@ BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -65,4 +66,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [targets]
-test = ["SafeTestsets", "Pkg", "Test", "Aqua", "Random", "SparseArrays", "SuiteSparse", "BandedMatrices", "BlockBandedMatrices", "GPUArraysCore", "StaticArrays", "StaticArraysCore", "Tracker", "ReverseDiff", "ChainRules"]
+test = ["SafeTestsets", "Pkg", "Test", "Aqua", "Random", "SparseArrays", "SuiteSparse", "BandedMatrices", "BlockBandedMatrices", "GPUArraysCore", "StaticArrays", "StaticArraysCore", "Tracker", "ReverseDiff", "ChainRules", "ComponentArrays"]

--- a/docs/src/conversions.md
+++ b/docs/src/conversions.md
@@ -12,4 +12,5 @@ ArrayInterface.aos_to_soa
 ArrayInterface.promote_eltype
 ArrayInterface.restructure
 ArrayInterface.safevec
+ArrayInterface.has_trivial_array_constructor
 ```

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -1001,7 +1001,7 @@ ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(
 ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
 
 function has_trivial_array_contstructor(::Type{T}, args...) where T
-    applicable(T, args...)
+    applicable(convert, T, args...)
 end
 
 end # module

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -1000,4 +1000,8 @@ ensures_sorted(@nospecialize( T::Type{<:AbstractRange})) = true
 ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(T)) : false
 ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
 
+function has_trivial_array_contstructor(::Type{T}, args...) as T
+    applicable(T, args...)
+end
+
 end # module

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -1000,6 +1000,26 @@ ensures_sorted(@nospecialize( T::Type{<:AbstractRange})) = true
 ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(T)) : false
 ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
 
+"""
+    has_trivial_array_constructor(T::Type, args...) -> Bool
+
+Returns `true` if an object of type `T` can be constructed using the collection of `args`
+
+Note: This checks if a compatible `convert` methood exists between `T` and `args`
+
+# Examples:
+
+```julia
+julia> ca = ComponentVector((x = rand(3), y = rand(4),))
+ComponentVector{Float64}(x = [0.6549137106381634, 0.37555505280294565, 0.8521039568665254], y = [0.40314196291239024, 0.35484725607638834, 0.6580528978034597, 0.10055508457632167])
+
+julia> ArrayInterface.has_trivial_array_constructor(typeof(ca), ones(6))
+true
+
+julia> ArrayInterface.has_trivial_array_constructor(typeof(cv), (x = rand(6),))
+false
+```
+"""
 function has_trivial_array_constructor(::Type{T}, args...) where T
     applicable(convert, T, args...)
 end

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -1000,7 +1000,7 @@ ensures_sorted(@nospecialize( T::Type{<:AbstractRange})) = true
 ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(T)) : false
 ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
 
-function has_trivial_array_contstructor(::Type{T}, args...) as T
+function has_trivial_array_contstructor(::Type{T}, args...) where T
     applicable(T, args...)
 end
 

--- a/src/ArrayInterface.jl
+++ b/src/ArrayInterface.jl
@@ -1000,7 +1000,7 @@ ensures_sorted(@nospecialize( T::Type{<:AbstractRange})) = true
 ensures_sorted(T::Type) = is_forwarding_wrapper(T) ? ensures_sorted(parent_type(T)) : false
 ensures_sorted(@nospecialize(x)) = ensures_sorted(typeof(x))
 
-function has_trivial_array_contstructor(::Type{T}, args...) where T
+function has_trivial_array_constructor(::Type{T}, args...) where T
     applicable(convert, T, args...)
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -2,6 +2,7 @@ using ArrayInterface
 using ArrayInterface: zeromatrix, undefmatrix
 import ArrayInterface: has_sparsestruct, findstructralnz, fast_scalar_indexing, lu_instance,
         parent_type, zeromatrix
+using ComponentArrays
 using LinearAlgebra
 using Random
 using SparseArrays
@@ -289,4 +290,9 @@ end
         end
         @test ArrayInterface.ldlt_instance(SymTridiagonal(A' * A)) isa typeof(ldlt(SymTridiagonal(A' * A)))
     end
+end
+
+@testset "Array conversion" begin
+    cv = ComponentVector((x = rand(3), y = rand(3)))
+    @test ArrayInterface.has_trivial_array_constructor(typeof(cv), rand(6))
 end


### PR DESCRIPTION
We need to know if we can construct the parent type given some arguments. This adds a check for whether an `applicable` method exists. It currently doesn't check for unionalls, and I am not sure of how to check for them. In some cases we want to keep the concrete type:

```julia
julia> ca = ComponentVector((x = rand(3), y = rand(4),))
ComponentVector{Float64}(x = [0.6549137106381634, 0.37555505280294565, 0.8521039568665254], y = [0.40314196291239024, 0.35484725607638834, 0.6580528978034597, 0.10055508457632167])

julia> convert(typeof(ca), rand(7))
ComponentVector{Float64}(x = [0.2282005678229746, 0.5803510438411744, 0.734611658286954], y = [0.9325262248600694, 0.49927588841708803, 0.01698109918493529, 0.16806075729787862])
```

I also need to understand what the appropriate tests here would be.