### PR TITLE
revert #449

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [extensions]
@@ -27,7 +27,7 @@ ArrayInterfaceChainRulesExt = "ChainRules"
 ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
 ArrayInterfaceReverseDiffExt = "ReverseDiff"
 ArrayInterfaceSparseArraysExt = "SparseArrays"
-ArrayInterfaceStaticArraysExt = "StaticArrays"
+ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
 ArrayInterfaceTrackerExt = "Tracker"
 
 [compat]

--- a/ext/ArrayInterfaceStaticArraysCoreExt.jl
+++ b/ext/ArrayInterfaceStaticArraysCoreExt.jl
@@ -21,10 +21,6 @@ ArrayInterface.can_setindex(::Type{<:StaticArray}) = false
 ArrayInterface.can_setindex(::Type{<:MArray}) = true
 ArrayInterface.buffer(A::Union{SArray, MArray}) = getfield(A, :data)
 
-function ArrayInterface.lu_instance(A::SMatrix{N,N}) where {N}
-    LU(LowerTriangular(A), UpperTriangular(A), SVector{N}(1:N))
-end
-
 function ArrayInterface.lu_instance(A::StaticMatrix{N,N}) where {N}
     lu(one(A))
 end

--- a/ext/ArrayInterfaceStaticArraysCoreExt.jl
+++ b/ext/ArrayInterfaceStaticArraysCoreExt.jl
@@ -1,8 +1,8 @@
-module ArrayInterfaceStaticArraysExt
+module ArrayInterfaceStaticArraysCoreExt
 
 import ArrayInterface
 using LinearAlgebra
-import StaticArrays: SArray, SMatrix, SVector, StaticMatrix, StaticArray, SizedArray, MArray, MMatrix, LU
+import StaticArraysCore: SArray, SMatrix, SVector, StaticMatrix, StaticArray, SizedArray, MArray, MMatrix
 
 function ArrayInterface.undefmatrix(::MArray{S, T, N, L}) where {S, T, N, L}
     return MMatrix{L, L, T, L*L}(undef)


### PR DESCRIPTION
Since the SArray types are created in StaticArraysCore, unfortunately we need the extension to be on the library or else generated functions in 3rd party packages can miss the added methods. Furthermore, this breaks the ability to optimize `lu` since `StaticArraysCore` doesn't define `StaticArrays.LU` so this just is really annoying. I really think we should delete StaticArraysCore and just make it an alias for StaticArrays now that extension packages exist.