### PR TITLE
Fully qualify constructor extension

### DIFF
--- a/ext/ArrayInterfaceBandedMatricesExt.jl
+++ b/ext/ArrayInterfaceBandedMatricesExt.jl
@@ -46,7 +46,7 @@ function _bandsize(bandind, rowsize, colsize)
     end
 end
 
-function BandedMatrixIndex(rowsize, colsize, lowerbandwidth, upperbandwidth, isrow)
+function ArrayInterface.BandedMatrixIndex(rowsize, colsize, lowerbandwidth, upperbandwidth, isrow)
     upperbandwidth > -lowerbandwidth || throw(ErrorException("Invalid Bandwidths"))
     bandinds = upperbandwidth:-1:(-lowerbandwidth)
     bandsizes = [_bandsize(band, rowsize, colsize) for band in bandinds]


### PR DESCRIPTION
Extending constructors without module specification can lead to undefined behaviour in case of name clashes.  This is fixed by fully qualifying `ArrayInterface.BandedMatrixIndex` when it is extended in the banded matrix ext.