### PR TITLE
Fix GitHub Actions version tags

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -28,8 +28,8 @@ jobs:
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@1
-      - uses: julia-actions/julia-runtest@1
+      - uses: julia-actions/julia-buildpkg@v2
+      - uses: julia-actions/julia-runtest@v2
         with:
           ALLOW_RERESOLVE: false
         env:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,36 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'benchmark/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'benchmark/**'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        downgrade_mode: ['alldeps']
+        julia-version: ['1.10']
+        group: ['Core']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          skip: Pkg,TOML
+      - uses: julia-actions/julia-buildpkg@1
+      - uses: julia-actions/julia-runtest@1
+        with:
+          ALLOW_RERESOLVE: false
+        env:
+          GROUP: ${{ matrix.group }}

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -20,14 +20,14 @@ jobs:
       with:
         version: '1'
     - uses: actions/checkout@v4
-    - uses: julia-actions/julia-buildpkg@v1
+    - uses: julia-actions/julia-buildpkg@v2
     - uses: julia-actions/julia-invalidations@v1
       id: invs_pr
 
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.repository.default_branch }}
-    - uses: julia-actions/julia-buildpkg@v1
+    - uses: julia-actions/julia-buildpkg@v2
     - uses: julia-actions/julia-invalidations@v1
       id: invs_default
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-buildpkg@v2
+      - uses: julia-actions/julia-runtest@v2
         env:
           GROUP: ${{ matrix.group }}
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions version tags that were causing CI failures
- Updated `julia-actions/julia-buildpkg` and `julia-actions/julia-runtest` from `@1`/`@v1` to `@v2`
- Fixed version tags in `ci.yml`, `Downgrade.yml`, and `Invalidations.yml`

## Changes
- `ci.yml`: Updated buildpkg and runtest actions from `@v1` to `@v2`
- `Downgrade.yml`: Updated buildpkg and runtest actions from `@1` to `@v2`
- `Invalidations.yml`: Updated buildpkg actions from `@v1` to `@v2`

## Test plan
- [x] CI now runs successfully with the corrected action versions
- [x] All workflow files use consistent and valid version tags

🤖 Generated with [Claude Code](https://claude.ai/code)