### PR TITLE
Fix restructure pullback source projection

### DIFF
--- a/ext/ArrayInterfaceChainRulesCoreExt.jl
+++ b/ext/ArrayInterfaceChainRulesCoreExt.jl
@@ -5,13 +5,13 @@ import ChainRulesCore
 import ChainRulesCore: unthunk, NoTangent, ZeroTangent, ProjectTo, @thunk
 
 function ChainRulesCore.rrule(::typeof(ArrayInterface.restructure), target, src)
-    projectT = ProjectTo(target)
+    projectS = ProjectTo(src)
     function restructure_pullback(dt)
         dt = unthunk(dt)
 
         f̄ = NoTangent()
         t̄ = ZeroTangent()
-        s̄ = @thunk(projectT(ArrayInterface.restructure(src, dt)))
+        s̄ = @thunk(projectS(ArrayInterface.restructure(src, dt)))
 
         f̄, t̄, s̄
     end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -11,3 +11,4 @@ b = zeros(length(arr))
 
 ChainRulesTestUtils.test_rrule(ArrayInterface.restructure, arr, b)
 ChainRulesTestUtils.test_rrule(ArrayInterface.restructure, b, arr)
+ChainRulesTestUtils.test_rrule(ArrayInterface.restructure, zeros(2, 2), zeros(4))


### PR DESCRIPTION
## Summary

Project `restructure` pullback cotangents into the differentiated source's tangent space instead of the target's. The existing rule fails whenever `target` and `src` have different array shapes, including SciMLSensitivity's mixed GPU/CPU adjoint test with matrix parameters.

> Ignore this PR until reviewed by @ChrisRackauckas.

## Root cause

`restructure(target, src)` returns values from `src` arranged like `target`. Its pullback reconstructs the output cotangent into `src`'s layout, but then applies `ProjectTo(target)`. A flat source and matrix target therefore produce a flat cotangent that the matrix projector rejects.

The rule must project with `ProjectTo(src)`: the third pullback result is the cotangent of the third argument.

## Failing before

The added ChainRules test uses a `2×2` matrix target and length-4 vector source. On clean `master` at `97b9fe8`, the full Core group reached the new test and failed:

```text
$ GROUP=Core julia +release --project=. -e 'using Pkg; Pkg.test()'
test_rrule: restructure on Matrix{Float64},Vector{Float64}: Error During Test
DimensionMismatch: variable with size(x) == (2, 2) cannot have a gradient with size(dx) == (4,)
Test Summary: | Pass  Error  Total
ChainRules    |   26      1     27
ERROR: Some tests did not pass: 26 passed, 0 failed, 1 errored, 0 broken.
```

## Passing after

The same full group passes with the source projector:

```text
$ GROUP=Core julia +release --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
ChainRules    |   29     29  24.7s
Test Summary: | Pass  Total  Time
FillArrays    |    7      7  0.0s
Testing ArrayInterface tests passed

$ GROUP=Core julia +lts --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
ChainRules    |   29     29  16.6s
Test Summary: | Pass  Total  Time
FillArrays    |    7      7  0.0s
Testing ArrayInterface tests passed
```

The exact CPU analogue of SciMLSensitivity's failing matrix-parameter `BacksolveAdjoint(autojacvec = ZygoteVJP())` path also passes against this checkout and agrees with ForwardDiff:

```text
matrix_parameter_gradient_pass relerr=4.4129021327423305e-9
```

## Additional verification

```text
$ julia +release -e '<JuliaFormatter SciMLStyle check>' ext/ArrayInterfaceChainRulesCoreExt.jl test/chainrules.jl
# exit 0

$ typos ext/ArrayInterfaceChainRulesCoreExt.jl test/chainrules.jl
# exit 0

$ git diff --check
# exit 0
```

The repository has no QA test group. An additional direct `Aqua.test_all(ArrayInterface)` run failed only its stale-dependency check for `Adapt`. Independent audit showed that this is an extension-awareness false positive: the base load intentionally omits `Adapt`, while loading `GPUArraysCore` activates `ArrayInterfaceGPUArraysCoreExt`, which imports and uses it. The CUDA job was not run locally because this host has no NVIDIA device. ArrayInterface's existing downstream CI covers SciMLSensitivity Core1–Core5.

## Links

- Current SciMLSensitivity GPU failure: https://github.com/SciML/SciMLSensitivity.jl/actions/runs/33399415653/job/99511763176
- Closed narrow SciMLSensitivity workaround: https://github.com/SciML/SciMLSensitivity.jl/pull/1633
- Pullback introduction: https://github.com/JuliaArrays/ArrayInterface.jl/commit/c7216c3241346d550f3ac2a4fe0211161e268ffe

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
